### PR TITLE
Fix wave file header lengths

### DIFF
--- a/src/recorder/cwavestream.cpp
+++ b/src/recorder/cwavestream.cpp
@@ -120,10 +120,13 @@ void CWaveStream::waveStreamHeaders()
     *this << scHdrRiff << cFmtSubChunk << scDataSubChunkHdr;
 }
 
-CWaveStream::~CWaveStream()
+void CWaveStream::finalise()
 {
+    static const uint32_t hdrRiffChunkSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
+    static const uint32_t fmtSubChunkSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t);
+
     static const uint32_t hdrRiffChunkSizeOffset = sizeof(uint32_t);
-    static const uint32_t dataSubChunkHdrChunkSizeOffset = sizeof(HdrRiff) + sizeof(FmtSubChunk) + sizeof (uint32_t) + sizeof (uint32_t);
+    static const uint32_t dataSubChunkHdrChunkSizeOffset = hdrRiffChunkSize + fmtSubChunkSize + sizeof (uint32_t);
 
     const int64_t currentPos = this->device()->pos();
     const uint32_t fileLength = static_cast<uint32_t>(currentPos - initialPos);

--- a/src/recorder/cwavestream.h
+++ b/src/recorder/cwavestream.h
@@ -73,7 +73,8 @@ public:
     explicit CWaveStream(QIODevice *iod, const uint16_t numChannels);
     CWaveStream(QByteArray *iod, QIODevice::OpenMode flags, const uint16_t numChannels);
     CWaveStream(const QByteArray &ba, const uint16_t numChannels);
-    ~CWaveStream();
+
+    void finalise();
 
 private:
     void waveStreamHeaders();

--- a/src/recorder/jamrecorder.cpp
+++ b/src/recorder/jamrecorder.cpp
@@ -87,7 +87,7 @@ void CJamClient::Frame(const QString _name, const CVector<int16_t>& pcm)
  */
 void CJamClient::Disconnect()
 {
-    delete out;
+    static_cast<CWaveStream*>(out)->finalise();
     out = nullptr;
 
     wavFile->close();


### PR DESCRIPTION
* `~CWaveStream()` was not being called - no idea why.
* I had the offsets wrong anyway.