### PR TITLE
Enhance historygraph to allow size based on date

### DIFF
--- a/src/historygraph.cpp
+++ b/src/historygraph.cpp
@@ -135,6 +135,9 @@ void AHistoryGraph::Update ( )
         // store current date for reference
         curDate = QDate::currentDate();
 
+        // set oldest date to draw
+        QDate     minDate             = curDate.addDays ( MAX_DAYS_HISTORY * -1 );
+
         // get oldest date in history
         QDate     oldestDate          = curDate.addDays ( 1 ); // one day in the future
         const int iNumItemsForHistory = vHistoryDataFifo.Size();
@@ -150,6 +153,10 @@ void AHistoryGraph::Update ( )
                 }
             }
         }
+        if (oldestDate < minDate)
+        {
+            oldestDate = minDate;
+        }
         const int iNumDaysInHistory = -curDate.daysTo ( oldestDate ) + 1;
 
         // draw frame of the graph
@@ -159,7 +166,7 @@ void AHistoryGraph::Update ( )
         for ( i = 0; i < iNumItemsForHistory; i++ )
         {
             // only use valid dates
-            if ( vHistoryDataFifo[i].DateTime.date().isValid() )
+            if ( vHistoryDataFifo[i].DateTime.date().isValid() && oldestDate <= vHistoryDataFifo[i].DateTime.date() )
             {
                 AddMarker ( vHistoryDataFifo[i] );
             }

--- a/src/historygraph.h
+++ b/src/historygraph.h
@@ -44,7 +44,9 @@
 
 /* Definitions ****************************************************************/
 // number of history items to store
-#define NUM_ITEMS_HISTORY           600
+#define NUM_ITEMS_HISTORY           4800
+// oldest item to draw
+#define MAX_DAYS_HISTORY            60
 
 
 /* Interface ******************************************************************/


### PR DESCRIPTION
Due to the increasing number of connections, the *number* of history
entries is no longer a good way to size the width of the graph.
In addition to adding a much larger FIFO, I have chosen to add
a date constraint.  This means I do not have to keep making the FIFO
bigger daily and, when numbers fall, the graph will not change
shape.