### PR TITLE
Feature/covid19 date limit on historygraph

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -92,12 +92,8 @@ LED bar:      lbr
 // file name for logging file
 #define DEFAULT_LOG_FILE_NAME           "Jamulussrvlog.txt"
 
-/* History Definitions ****************************************************************/
-// default number of history items to store
-#define NUM_ITEMS_HISTORY           6400
-// default oldest item to draw
-#define MAX_DAYS_HISTORY            60
-/* *** */
+// Default oldest item to draw in history graph (days ago)
+#define DEFAULT_DAYS_HISTORY            60
 
 // default server address
 #define DEFAULT_SERVER_ADDRESS          "jamulus.fischvolk.de"

--- a/src/global.h
+++ b/src/global.h
@@ -92,6 +92,13 @@ LED bar:      lbr
 // file name for logging file
 #define DEFAULT_LOG_FILE_NAME           "Jamulussrvlog.txt"
 
+/* History Definitions ****************************************************************/
+// default number of history items to store
+#define NUM_ITEMS_HISTORY           6400
+// default oldest item to draw
+#define MAX_DAYS_HISTORY            60
+/* *** */
+
 // default server address
 #define DEFAULT_SERVER_ADDRESS          "jamulus.fischvolk.de"
 #define DEFAULT_SERVER_NAME             "Central Server"

--- a/src/historygraph.cpp
+++ b/src/historygraph.cpp
@@ -27,11 +27,13 @@
 
 
 /* Abstract class *************************************************************/
-AHistoryGraph::AHistoryGraph() :
+AHistoryGraph::AHistoryGraph( const int          iNumItemsHistory,
+                              const int          iMaxDaysHistory ) :
     sFileName           ( "" ),
     bDoHistory          ( false ),
-    vHistoryDataFifo    ( NUM_ITEMS_HISTORY ),
+    vHistoryDataFifo    ( iNumItemsHistory ),
     iNumTicksX          ( 0 ), // number of days in history
+    iHistMaxDays        ( iMaxDaysHistory ),
 
     BackgroundColor     ( "white" ), // background
     FrameColor          ( "black" ), // frame
@@ -136,7 +138,7 @@ void AHistoryGraph::Update ( )
         curDate = QDate::currentDate();
 
         // set oldest date to draw
-        QDate minDate = curDate.addDays ( MAX_DAYS_HISTORY * -1 );
+        QDate     minDate             = curDate.addDays ( iHistMaxDays * -1 );
 
         // get oldest date in history
         QDate     oldestDate          = curDate.addDays ( 1 ); // one day in the future
@@ -298,9 +300,10 @@ void AHistoryGraph::AddMarker ( const SHistoryData& curHistoryData )
 
 
 /* JPEG History Graph implementation ******************************************/
-CJpegHistoryGraph::CJpegHistoryGraph() :
-    AHistoryGraph(),
-    PlotPixmap ( 1, 1, QImage::Format_RGB32 ),
+CJpegHistoryGraph::CJpegHistoryGraph( const int          iNumItemsHistory,
+                                      const int          iMaxDaysHistory ) :
+    AHistoryGraph   ( iNumItemsHistory, iMaxDaysHistory ),
+    PlotPixmap      ( 1, 1, QImage::Format_RGB32 ),
     iAxisFontWeight ( -1 )
 {
     // scale pixmap to correct size
@@ -403,9 +406,10 @@ void CJpegHistoryGraph::point ( const unsigned int x, const unsigned int y, cons
 
 
 /* SVG History Graph implementation *******************************************/
-CSvgHistoryGraph::CSvgHistoryGraph() :
-    AHistoryGraph(),
-    svgImage ( "" ),
+CSvgHistoryGraph::CSvgHistoryGraph( const int          iNumItemsHistory,
+                                    const int          iMaxDaysHistory ) :
+    AHistoryGraph   ( iNumItemsHistory, iMaxDaysHistory ),
+    svgImage        ( "" ),
     svgStreamWriter ( &svgImage )
 {
     // set SVG veiwBox to correct size to ensure correct scaling

--- a/src/historygraph.cpp
+++ b/src/historygraph.cpp
@@ -67,8 +67,8 @@ AHistoryGraph::AHistoryGraph() :
     iTextOffsetToGrid   ( 3 ),
     iTextOffsetX        ( 18 ),
 
-    iMarkerSizeNewCon   ( 11 ),
-    iMarkerSizeServSt   ( 8 )
+    iMarkerSizeNewCon   ( 10 ),
+    iMarkerSizeServSt   ( 6 )
 {
 }
 

--- a/src/historygraph.cpp
+++ b/src/historygraph.cpp
@@ -27,11 +27,10 @@
 
 
 /* Abstract class *************************************************************/
-AHistoryGraph::AHistoryGraph( const int          iNumItemsHistory,
-                              const int          iMaxDaysHistory ) :
+AHistoryGraph::AHistoryGraph( const int          iMaxDaysHistory ) :
     sFileName           ( "" ),
     bDoHistory          ( false ),
-    vHistoryDataFifo    ( iNumItemsHistory ),
+    vHistoryDataFifo    ( NUM_ITEMS_HISTORY ),
     iNumTicksX          ( 0 ), // number of days in history
     iHistMaxDays        ( iMaxDaysHistory ),
 
@@ -300,9 +299,8 @@ void AHistoryGraph::AddMarker ( const SHistoryData& curHistoryData )
 
 
 /* JPEG History Graph implementation ******************************************/
-CJpegHistoryGraph::CJpegHistoryGraph( const int          iNumItemsHistory,
-                                      const int          iMaxDaysHistory ) :
-    AHistoryGraph   ( iNumItemsHistory, iMaxDaysHistory ),
+CJpegHistoryGraph::CJpegHistoryGraph( const int          iMaxDaysHistory ) :
+    AHistoryGraph   ( iMaxDaysHistory ),
     PlotPixmap      ( 1, 1, QImage::Format_RGB32 ),
     iAxisFontWeight ( -1 )
 {
@@ -406,9 +404,8 @@ void CJpegHistoryGraph::point ( const unsigned int x, const unsigned int y, cons
 
 
 /* SVG History Graph implementation *******************************************/
-CSvgHistoryGraph::CSvgHistoryGraph( const int          iNumItemsHistory,
-                                    const int          iMaxDaysHistory ) :
-    AHistoryGraph   ( iNumItemsHistory, iMaxDaysHistory ),
+CSvgHistoryGraph::CSvgHistoryGraph( const int          iMaxDaysHistory ) :
+    AHistoryGraph   ( iMaxDaysHistory ),
     svgImage        ( "" ),
     svgStreamWriter ( &svgImage )
 {

--- a/src/historygraph.h
+++ b/src/historygraph.h
@@ -53,7 +53,8 @@ public:
         HIT_SERVER_STOP
     };
 
-    AHistoryGraph();
+    AHistoryGraph( const int          iNumItemsHistory,
+                   const int          iMaxDaysHistory );
     ~AHistoryGraph() { }
 
     void Start ( const QString& sNewFileName );
@@ -81,6 +82,7 @@ protected:
     bool                bDoHistory;
     CFIFO<SHistoryData> vHistoryDataFifo;
     unsigned int        iNumTicksX; // Class global, not sure why
+    int                 iHistMaxDays;
 
     QString             BackgroundColor;
     QString             FrameColor;
@@ -133,7 +135,8 @@ class CJpegHistoryGraph : public QObject, virtual public AHistoryGraph
     Q_OBJECT
 
 public:
-    CJpegHistoryGraph();
+    CJpegHistoryGraph( const int          iNumItemsHistory,
+                       const int          iMaxDaysHistory );
     virtual void Update ( );
 
 protected:
@@ -157,7 +160,8 @@ class CSvgHistoryGraph : public QObject, virtual public AHistoryGraph
     Q_OBJECT
 
 public:
-    CSvgHistoryGraph();
+    CSvgHistoryGraph( const int          iNumItemsHistory,
+                      const int          iMaxDaysHistory );
     virtual void Update();
 
 protected:

--- a/src/historygraph.h
+++ b/src/historygraph.h
@@ -42,6 +42,11 @@
 #include <QXmlStreamAttributes>
 
 
+/* Definitions ****************************************************************/
+// number of history items to store
+#define NUM_ITEMS_HISTORY           20000
+
+
 /* Interface ******************************************************************/
 class AHistoryGraph
 {
@@ -53,8 +58,7 @@ public:
         HIT_SERVER_STOP
     };
 
-    AHistoryGraph( const int          iNumItemsHistory,
-                   const int          iMaxDaysHistory );
+    AHistoryGraph( const int          iMaxDaysHistory );
     ~AHistoryGraph() { }
 
     void Start ( const QString& sNewFileName );
@@ -135,8 +139,7 @@ class CJpegHistoryGraph : public QObject, virtual public AHistoryGraph
     Q_OBJECT
 
 public:
-    CJpegHistoryGraph( const int          iNumItemsHistory,
-                       const int          iMaxDaysHistory );
+    CJpegHistoryGraph( const int          iMaxDaysHistory );
     virtual void Update ( );
 
 protected:
@@ -160,8 +163,7 @@ class CSvgHistoryGraph : public QObject, virtual public AHistoryGraph
     Q_OBJECT
 
 public:
-    CSvgHistoryGraph( const int          iNumItemsHistory,
-                      const int          iMaxDaysHistory );
+    CSvgHistoryGraph( const int          iMaxDaysHistory );
     virtual void Update();
 
 protected:

--- a/src/historygraph.h
+++ b/src/historygraph.h
@@ -42,14 +42,6 @@
 #include <QXmlStreamAttributes>
 
 
-/* Definitions ****************************************************************/
-// number of history items to store
-#define NUM_ITEMS_HISTORY           4800
-
-// oldest item to draw
-#define MAX_DAYS_HISTORY            60
-
-
 /* Interface ******************************************************************/
 class AHistoryGraph
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,8 @@ int main ( int argc, char** argv )
     bool         bCentServPingServerInList = false;
     bool         bNoAutoJackConnect        = false;
     int          iNumServerChannels        = DEFAULT_USED_NUM_CHANNELS;
+    int          iNumItemsHistory          = NUM_ITEMS_HISTORY;
+    int          iMaxDaysHistory           = MAX_DAYS_HISTORY;
     int          iCtrlMIDIChannel          = INVALID_MIDI_CH;
     quint16      iPortNumber               = LLCON_DEFAULT_PORT_NUMBER;
     ELicenceType eLicenceType              = LT_NO_LICENCE;
@@ -128,6 +130,45 @@ int main ( int argc, char** argv )
             continue;
         }
 
+
+        // Maximum items in history display ------------------------------------
+        if ( GetNumericArgument ( tsConsole,
+                                  argc,
+                                  argv,
+                                  i,
+                                  "-I",
+                                  "--histitems",
+                                  1,
+                                  65535,
+                                  rDbleArgument ) )
+        {
+            iNumItemsHistory = static_cast<int> ( rDbleArgument );
+
+            tsConsole << "- maximum items in history display: "
+                << iNumItemsHistory << endl;
+
+            continue;
+        }
+
+
+        // Maximum days in history display ------------------------------------
+        if ( GetNumericArgument ( tsConsole,
+                                  argc,
+                                  argv,
+                                  i,
+                                  "-D",
+                                  "--histdays",
+                                  1,
+                                  366,
+                                  rDbleArgument ) )
+        {
+            iMaxDaysHistory = static_cast<int> ( rDbleArgument );
+
+            tsConsole << "- maximum days in history display: "
+                << iMaxDaysHistory << endl;
+
+            continue;
+        }
 
 
         // Start minimized -----------------------------------------------------
@@ -496,6 +537,8 @@ int main ( int argc, char** argv )
             // Server:
             // actual server object
             CServer Server ( iNumServerChannels,
+                             iNumItemsHistory,
+                             iMaxDaysHistory,
                              strLoggingFileName,
                              iPortNumber,
                              strHTMLStatusFileName,
@@ -610,6 +653,8 @@ QString UsageArguments ( char **argv )
         "  -w, --welcomemessage  welcome message on connect (server only)\n"
         "  -y, --history         enable connection history and set file\n"
         "                        name (server only)\n"
+        "  -I, --histitems       number of history items to display (server only)\n"
+        "  -D, --histdays        number of days of history to display (server only)\n"
         "  -z, --startminimized  start minimizied (server only)\n"
         "  --ctrlmidich          MIDI controller channel to listen (client only)"
         "\nExample: " + QString ( argv[0] ) + " -l -inifile myinifile.ini\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,8 +53,7 @@ int main ( int argc, char** argv )
     bool         bCentServPingServerInList = false;
     bool         bNoAutoJackConnect        = false;
     int          iNumServerChannels        = DEFAULT_USED_NUM_CHANNELS;
-    int          iNumItemsHistory          = NUM_ITEMS_HISTORY;
-    int          iMaxDaysHistory           = MAX_DAYS_HISTORY;
+    int          iMaxDaysHistory           = DEFAULT_DAYS_HISTORY;
     int          iCtrlMIDIChannel          = INVALID_MIDI_CH;
     quint16      iPortNumber               = LLCON_DEFAULT_PORT_NUMBER;
     ELicenceType eLicenceType              = LT_NO_LICENCE;
@@ -130,25 +129,6 @@ int main ( int argc, char** argv )
             continue;
         }
 
-
-        // Maximum items in history display ------------------------------------
-        if ( GetNumericArgument ( tsConsole,
-                                  argc,
-                                  argv,
-                                  i,
-                                  "-I",
-                                  "--histitems",
-                                  1,
-                                  65535,
-                                  rDbleArgument ) )
-        {
-            iNumItemsHistory = static_cast<int> ( rDbleArgument );
-
-            tsConsole << "- maximum items in history display: "
-                << iNumItemsHistory << endl;
-
-            continue;
-        }
 
 
         // Maximum days in history display ------------------------------------
@@ -537,7 +517,6 @@ int main ( int argc, char** argv )
             // Server:
             // actual server object
             CServer Server ( iNumServerChannels,
-                             iNumItemsHistory,
                              iMaxDaysHistory,
                              strLoggingFileName,
                              iPortNumber,
@@ -653,7 +632,6 @@ QString UsageArguments ( char **argv )
         "  -w, --welcomemessage  welcome message on connect (server only)\n"
         "  -y, --history         enable connection history and set file\n"
         "                        name (server only)\n"
-        "  -I, --histitems       number of history items to display (server only)\n"
         "  -D, --histdays        number of days of history to display (server only)\n"
         "  -z, --startminimized  start minimizied (server only)\n"
         "  --ctrlmidich          MIDI controller channel to listen (client only)"

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -198,6 +198,8 @@ void CHighPrecisionTimer::run()
 
 // CServer implementation ******************************************************
 CServer::CServer ( const int          iNewMaxNumChan,
+                   const int          iNumItemsHistory,
+                   const int          iMaxDaysHistory,
                    const QString&     strLoggingFileName,
                    const quint16      iPortNumber,
                    const QString&     strHTMLStatusFileName,
@@ -212,6 +214,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
                    const ELicenceType eNLicenceType ) :
     iMaxNumChannels       ( iNewMaxNumChan ),
     Socket                ( this, iPortNumber ),
+    Logging               ( iNumItemsHistory, iMaxDaysHistory ),
     JamRecorder           ( strRecordingDirName ),
     bEnableRecording      ( !strRecordingDirName.isEmpty() ),
     bWriteStatusHTMLFile  ( false ),

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -198,7 +198,6 @@ void CHighPrecisionTimer::run()
 
 // CServer implementation ******************************************************
 CServer::CServer ( const int          iNewMaxNumChan,
-                   const int          iNumItemsHistory,
                    const int          iMaxDaysHistory,
                    const QString&     strLoggingFileName,
                    const quint16      iPortNumber,
@@ -214,7 +213,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
                    const ELicenceType eNLicenceType ) :
     iMaxNumChannels       ( iNewMaxNumChan ),
     Socket                ( this, iPortNumber ),
-    Logging               ( iNumItemsHistory, iMaxDaysHistory ),
+    Logging               ( iMaxDaysHistory ),
     JamRecorder           ( strRecordingDirName ),
     bEnableRecording      ( !strRecordingDirName.isEmpty() ),
     bWriteStatusHTMLFile  ( false ),

--- a/src/server.h
+++ b/src/server.h
@@ -119,6 +119,8 @@ class CServer : public QObject
 
 public:
     CServer ( const int          iNewMaxNumChan,
+              const int          iNumItemsHistory,
+              const int          iMaxDaysHistory,
               const QString&     strLoggingFileName,
               const quint16      iPortNumber,
               const QString&     strHTMLStatusFileName,

--- a/src/server.h
+++ b/src/server.h
@@ -119,7 +119,6 @@ class CServer : public QObject
 
 public:
     CServer ( const int          iNewMaxNumChan,
-              const int          iNumItemsHistory,
               const int          iMaxDaysHistory,
               const QString&     strLoggingFileName,
               const quint16      iPortNumber,

--- a/src/serverlogging.cpp
+++ b/src/serverlogging.cpp
@@ -25,10 +25,9 @@
 #include "serverlogging.h"
 
 // Server logging --------------------------------------------------------------
-CServerLogging::CServerLogging( const int          iNumItemsHistory,
-                                const int          iMaxDaysHistory ) :
-    JpegHistoryGraph ( iNumItemsHistory, iMaxDaysHistory ),
-    SvgHistoryGraph ( iNumItemsHistory, iMaxDaysHistory ),
+CServerLogging::CServerLogging( const int          iMaxDaysHistory ) :
+    JpegHistoryGraph ( iMaxDaysHistory ),
+    SvgHistoryGraph ( iMaxDaysHistory ),
     bDoLogging ( false ),
     File ( DEFAULT_LOG_FILE_NAME )
 {

--- a/src/serverlogging.cpp
+++ b/src/serverlogging.cpp
@@ -25,6 +25,15 @@
 #include "serverlogging.h"
 
 // Server logging --------------------------------------------------------------
+CServerLogging::CServerLogging( const int          iNumItemsHistory,
+                                const int          iMaxDaysHistory ) :
+    JpegHistoryGraph ( iNumItemsHistory, iMaxDaysHistory ),
+    SvgHistoryGraph ( iNumItemsHistory, iMaxDaysHistory ),
+    bDoLogging ( false ),
+    File ( DEFAULT_LOG_FILE_NAME )
+{
+}
+
 CServerLogging::~CServerLogging()
 {
     // close logging file of open
@@ -82,8 +91,8 @@ void CServerLogging::AddServerStopped()
     *this << strLogStr; // in log file
 
     // add element to history and update on server stop
-    JpegHistoryGraph.Add ( QDateTime::currentDateTime(), CJpegHistoryGraph::HIT_SERVER_STOP );
-    SvgHistoryGraph.Add ( QDateTime::currentDateTime(), CJpegHistoryGraph::HIT_SERVER_STOP );
+    JpegHistoryGraph.Add ( QDateTime::currentDateTime(), AHistoryGraph::HIT_SERVER_STOP );
+    SvgHistoryGraph.Add ( QDateTime::currentDateTime(), AHistoryGraph::HIT_SERVER_STOP );
 
     JpegHistoryGraph.Update();
     SvgHistoryGraph.Update();
@@ -140,7 +149,7 @@ void CServerLogging::ParseLogFile ( const QString& strFileName )
                 if ( strAddress.isEmpty() )
                 {
                     // server stop
-                    JpegHistoryGraph.Add ( curDateTime, CJpegHistoryGraph::HIT_SERVER_STOP );
+                    JpegHistoryGraph.Add ( curDateTime, AHistoryGraph::HIT_SERVER_STOP );
                     SvgHistoryGraph.Add ( curDateTime, CSvgHistoryGraph::HIT_SERVER_STOP );
                 }
                 else

--- a/src/serverlogging.h
+++ b/src/serverlogging.h
@@ -38,8 +38,9 @@
 class CServerLogging
 {
 public:
-    CServerLogging() : bDoLogging ( false ),
-        File ( DEFAULT_LOG_FILE_NAME ) {}
+    CServerLogging( const int          iNumItemsHistory,
+                    const int          iMaxDaysHistory );
+
     virtual ~CServerLogging();
 
     void Start ( const QString& strLoggingFileName );
@@ -56,4 +57,8 @@ protected:
     CSvgHistoryGraph  SvgHistoryGraph;
     bool              bDoLogging;
     QFile             File;
+
+private:
+    int               iHistNumItems;
+    int               iHistMaxDays;
 };

--- a/src/serverlogging.h
+++ b/src/serverlogging.h
@@ -38,8 +38,7 @@
 class CServerLogging
 {
 public:
-    CServerLogging( const int          iNumItemsHistory,
-                    const int          iMaxDaysHistory );
+    CServerLogging( const int          iMaxDaysHistory );
 
     virtual ~CServerLogging();
 


### PR DESCRIPTION
OK, so an extension of the previous change (the previous one was the "easy" bit).

This adds support for passing the history graph number of nodes and days as program arguments.

(And I tuned the point sizes a little.)