### PR TITLE
Fix server bug causing crash when recording enabled

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -104,7 +104,7 @@ win32 {
     OTHER_FILES += android/AndroidManifest.xml
 } else:unix {
     # we want to compile with C++11
-    QMAKE_CXXFLAGS += -std=c++0x
+    QMAKE_CXXFLAGS += -std=c++11
 
     # we assume that stdint.h is always present in a Linux system
     DEFINES += HAVE_STDINT_H

--- a/src/recorder/jamrecorder.cpp
+++ b/src/recorder/jamrecorder.cpp
@@ -112,7 +112,8 @@ CJamSession::CJamSession(QDir recordBaseDir) :
     vecptrJamClients (MAX_NUM_CHANNELS),
     jamClientConnections()
 {
-    const QFileInfo fi(sessionDir.absolutePath());
+    QFileInfo fi(sessionDir.absolutePath());
+    fi.setCaching(false);
 
     if (!fi.exists() && !QDir().mkpath(sessionDir.absolutePath()))
     {
@@ -296,7 +297,8 @@ QMap<QString, QList<STrackItem>> CJamSession::TracksFromSessionDir(const QString
  */
 void CJamRecorder::Init(const CServer* server)
 {
-    const QFileInfo fi(recordBaseDir.absolutePath());
+    QFileInfo fi(recordBaseDir.absolutePath());
+    fi.setCaching(false);
 
     if (!fi.exists() && !QDir().mkpath(recordBaseDir.absolutePath()))
     {


### PR DESCRIPTION
Fix server bug preventing recording directory from being recognised after successful creation.
Small update to compiler flags.
Build tested on Ubuntu.