### PR TITLE
Add support for up to 50 clients

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -533,6 +533,16 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent, Qt::WindowFlags ) :
     QObject::connect ( vecpChanFader[37], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh37 ( double ) ) );
     QObject::connect ( vecpChanFader[38], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh38 ( double ) ) );
     QObject::connect ( vecpChanFader[39], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh39 ( double ) ) );
+    QObject::connect ( vecpChanFader[40], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh40 ( double ) ) );
+    QObject::connect ( vecpChanFader[41], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh41 ( double ) ) );
+    QObject::connect ( vecpChanFader[42], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh42 ( double ) ) );
+    QObject::connect ( vecpChanFader[43], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh43 ( double ) ) );
+    QObject::connect ( vecpChanFader[44], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh44 ( double ) ) );
+    QObject::connect ( vecpChanFader[45], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh45 ( double ) ) );
+    QObject::connect ( vecpChanFader[46], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh46 ( double ) ) );
+    QObject::connect ( vecpChanFader[47], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh47 ( double ) ) );
+    QObject::connect ( vecpChanFader[48], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh48 ( double ) ) );
+    QObject::connect ( vecpChanFader[49], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh49 ( double ) ) );
 
     QObject::connect ( vecpChanFader[0],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
     QObject::connect ( vecpChanFader[1],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
@@ -574,6 +584,16 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent, Qt::WindowFlags ) :
     QObject::connect ( vecpChanFader[37], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
     QObject::connect ( vecpChanFader[38], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
     QObject::connect ( vecpChanFader[39], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[40], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[41], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[42], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[43], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[44], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[45], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[46], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[47], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[48], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    QObject::connect ( vecpChanFader[49], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
 }
 
 void CAudioMixerBoard::SetServerName ( const QString& strNewServerName )

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -167,6 +167,16 @@ public slots:
     void OnGainValueChangedCh37 ( double dValue ) { OnGainValueChanged ( 37, dValue ); }
     void OnGainValueChangedCh38 ( double dValue ) { OnGainValueChanged ( 38, dValue ); }
     void OnGainValueChangedCh39 ( double dValue ) { OnGainValueChanged ( 39, dValue ); }
+    void OnGainValueChangedCh40 ( double dValue ) { OnGainValueChanged ( 40, dValue ); }
+    void OnGainValueChangedCh41 ( double dValue ) { OnGainValueChanged ( 41, dValue ); }
+    void OnGainValueChangedCh42 ( double dValue ) { OnGainValueChanged ( 42, dValue ); }
+    void OnGainValueChangedCh43 ( double dValue ) { OnGainValueChanged ( 43, dValue ); }
+    void OnGainValueChangedCh44 ( double dValue ) { OnGainValueChanged ( 44, dValue ); }
+    void OnGainValueChangedCh45 ( double dValue ) { OnGainValueChanged ( 45, dValue ); }
+    void OnGainValueChangedCh46 ( double dValue ) { OnGainValueChanged ( 46, dValue ); }
+    void OnGainValueChangedCh47 ( double dValue ) { OnGainValueChanged ( 47, dValue ); }
+    void OnGainValueChangedCh48 ( double dValue ) { OnGainValueChanged ( 48, dValue ); }
+    void OnGainValueChangedCh49 ( double dValue ) { OnGainValueChanged ( 49, dValue ); }
 
     void OnChSoloStateChanged() { UpdateSoloStates(); }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1143,6 +1143,8 @@ void CClientDlg::SetGUIDesign ( const EGUIDesign eNewDesign )
     switch ( eNewDesign )
     {
     case GD_ORIGINAL:
+        scrollAreaMixerBoard->setStyleSheet( "background: transparent;" );
+
         backgroundFrame->setStyleSheet (
             "QFrame#backgroundFrame { border-image:  url(:/png/fader/res/mixerboardbackground.png) 34px 30px 40px 40px;"
             "                         border-top:    34px transparent;"
@@ -1163,7 +1165,7 @@ void CClientDlg::SetGUIDesign ( const EGUIDesign eNewDesign )
             "QCheckBox::indicator:checked {"
             "                         image:          url(:/png/fader/res/ledbuttonpressed.png); }"
             "QCheckBox {              color:          rgb(148, 148, 148);"
-            "                         font:           bold; }" );            
+            "                         font:           bold; }" );
 
 #ifdef _WIN32
 // Workaround QT-Windows problem: This should not be necessary since in the
@@ -1180,7 +1182,9 @@ rbtReverbSelR->setStyleSheet ( "color: rgb(148, 148, 148);"
 
     default:
         // reset style sheet and set original paramters
+        scrollAreaMixerBoard->setStyleSheet( "" );
         backgroundFrame->setStyleSheet ( "" );
+
 
 #ifdef _WIN32
 // Workaround QT-Windows problem: See above description

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>345</width>
-    <height>363</height>
+    <width>800</width>
+    <height>350</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -568,13 +568,78 @@
        </layout>
       </item>
       <item>
-       <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <widget class="Line" name="lineMixerBoard">
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
         </property>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scrollAreaMixerBoard">
+        <property name="minimumSize">
+         <size>
+          <width>480</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaMixerBoardContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>480</width>
+           <height>323</height>
+          </rect>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>

--- a/src/global.h
+++ b/src/global.h
@@ -185,7 +185,7 @@ LED bar:      lbr
 // if you want to change this paramter, there has to be done code modifications
 // on other places, too! The code tag "MAX_NUM_CHANNELS_TAG" shows these places
 // (just search for the tag in the entire code)
-#define MAX_NUM_CHANNELS                40 // max number channels for server
+#define MAX_NUM_CHANNELS                50 // max number channels for server
 
 // actual number of used channels in the server
 // this parameter can safely be changed from 1 to MAX_NUM_CHANNELS

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -474,6 +474,16 @@ CServer::CServer ( const int          iNewMaxNumChan,
     QObject::connect ( &vecChannels[37], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh37 ( CVector<uint8_t> ) ) );
     QObject::connect ( &vecChannels[38], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh38 ( CVector<uint8_t> ) ) );
     QObject::connect ( &vecChannels[39], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh39 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[40], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh40 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[41], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh41 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[42], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh42 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[43], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh43 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[44], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh44 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[45], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh45 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[46], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh46 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[47], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh47 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[48], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh48 ( CVector<uint8_t> ) ) );
+    QObject::connect ( &vecChannels[49], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh49 ( CVector<uint8_t> ) ) );
 
     // request connected clients list
     QObject::connect ( &vecChannels[0],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh0() ) );
@@ -516,6 +526,16 @@ CServer::CServer ( const int          iNewMaxNumChan,
     QObject::connect ( &vecChannels[37], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh37() ) );
     QObject::connect ( &vecChannels[38], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh38() ) );
     QObject::connect ( &vecChannels[39], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh39() ) );
+    QObject::connect ( &vecChannels[40], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh40() ) );
+    QObject::connect ( &vecChannels[41], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh41() ) );
+    QObject::connect ( &vecChannels[42], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh42() ) );
+    QObject::connect ( &vecChannels[43], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh43() ) );
+    QObject::connect ( &vecChannels[44], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh44() ) );
+    QObject::connect ( &vecChannels[45], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh45() ) );
+    QObject::connect ( &vecChannels[46], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh46() ) );
+    QObject::connect ( &vecChannels[47], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh47() ) );
+    QObject::connect ( &vecChannels[48], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh48() ) );
+    QObject::connect ( &vecChannels[49], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh49() ) );
 
     // channel info has changed
     QObject::connect ( &vecChannels[0],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh0() ) );
@@ -558,6 +578,16 @@ CServer::CServer ( const int          iNewMaxNumChan,
     QObject::connect ( &vecChannels[37], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh37() ) );
     QObject::connect ( &vecChannels[38], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh38() ) );
     QObject::connect ( &vecChannels[39], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh39() ) );
+    QObject::connect ( &vecChannels[40], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh40() ) );
+    QObject::connect ( &vecChannels[41], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh41() ) );
+    QObject::connect ( &vecChannels[42], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh42() ) );
+    QObject::connect ( &vecChannels[43], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh43() ) );
+    QObject::connect ( &vecChannels[44], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh44() ) );
+    QObject::connect ( &vecChannels[45], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh45() ) );
+    QObject::connect ( &vecChannels[46], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh46() ) );
+    QObject::connect ( &vecChannels[47], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh47() ) );
+    QObject::connect ( &vecChannels[48], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh48() ) );
+    QObject::connect ( &vecChannels[49], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh49() ) );
 
     // chat text received
     QObject::connect ( &vecChannels[0],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh0  ( QString ) ) );
@@ -600,6 +630,16 @@ CServer::CServer ( const int          iNewMaxNumChan,
     QObject::connect ( &vecChannels[37], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh37 ( QString ) ) );
     QObject::connect ( &vecChannels[38], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh38 ( QString ) ) );
     QObject::connect ( &vecChannels[39], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh39 ( QString ) ) );
+    QObject::connect ( &vecChannels[40], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh40 ( QString ) ) );
+    QObject::connect ( &vecChannels[41], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh41 ( QString ) ) );
+    QObject::connect ( &vecChannels[42], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh42 ( QString ) ) );
+    QObject::connect ( &vecChannels[43], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh43 ( QString ) ) );
+    QObject::connect ( &vecChannels[44], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh44 ( QString ) ) );
+    QObject::connect ( &vecChannels[45], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh45 ( QString ) ) );
+    QObject::connect ( &vecChannels[46], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh46 ( QString ) ) );
+    QObject::connect ( &vecChannels[47], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh47 ( QString ) ) );
+    QObject::connect ( &vecChannels[48], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh48 ( QString ) ) );
+    QObject::connect ( &vecChannels[49], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh49 ( QString ) ) );
 
     // auto socket buffer size change
     QObject::connect ( &vecChannels[0],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh0  ( int ) ) );
@@ -642,6 +682,16 @@ CServer::CServer ( const int          iNewMaxNumChan,
     QObject::connect ( &vecChannels[37], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh37 ( int ) ) );
     QObject::connect ( &vecChannels[38], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh38 ( int ) ) );
     QObject::connect ( &vecChannels[39], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh39 ( int ) ) );
+    QObject::connect ( &vecChannels[40], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh40 ( int ) ) );
+    QObject::connect ( &vecChannels[41], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh41 ( int ) ) );
+    QObject::connect ( &vecChannels[42], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh42 ( int ) ) );
+    QObject::connect ( &vecChannels[43], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh43 ( int ) ) );
+    QObject::connect ( &vecChannels[44], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh44 ( int ) ) );
+    QObject::connect ( &vecChannels[45], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh45 ( int ) ) );
+    QObject::connect ( &vecChannels[46], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh46 ( int ) ) );
+    QObject::connect ( &vecChannels[47], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh47 ( int ) ) );
+    QObject::connect ( &vecChannels[48], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh48 ( int ) ) );
+    QObject::connect ( &vecChannels[49], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh49 ( int ) ) );
 
 
     // start the socket (it is important to start the socket after all

--- a/src/server.h
+++ b/src/server.h
@@ -393,17 +393,27 @@ public slots:
     void OnSendProtMessCh37 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 37, mess ); }
     void OnSendProtMessCh38 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 38, mess ); }
     void OnSendProtMessCh39 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 39, mess ); }
+    void OnSendProtMessCh40 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 40, mess ); }
+    void OnSendProtMessCh41 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 41, mess ); }
+    void OnSendProtMessCh42 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 42, mess ); }
+    void OnSendProtMessCh43 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 43, mess ); }
+    void OnSendProtMessCh44 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 44, mess ); }
+    void OnSendProtMessCh45 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 45, mess ); }
+    void OnSendProtMessCh46 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 46, mess ); }
+    void OnSendProtMessCh47 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 47, mess ); }
+    void OnSendProtMessCh48 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 48, mess ); }
+    void OnSendProtMessCh49 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 49, mess ); }
 
-    void OnReqConnClientsListCh0()  { CreateAndSendChanListForThisChan ( 0  ); }
-    void OnReqConnClientsListCh1()  { CreateAndSendChanListForThisChan ( 1  ); }
-    void OnReqConnClientsListCh2()  { CreateAndSendChanListForThisChan ( 2  ); }
-    void OnReqConnClientsListCh3()  { CreateAndSendChanListForThisChan ( 3  ); }
-    void OnReqConnClientsListCh4()  { CreateAndSendChanListForThisChan ( 4  ); }
-    void OnReqConnClientsListCh5()  { CreateAndSendChanListForThisChan ( 5  ); }
-    void OnReqConnClientsListCh6()  { CreateAndSendChanListForThisChan ( 6  ); }
-    void OnReqConnClientsListCh7()  { CreateAndSendChanListForThisChan ( 7  ); }
-    void OnReqConnClientsListCh8()  { CreateAndSendChanListForThisChan ( 8  ); }
-    void OnReqConnClientsListCh9()  { CreateAndSendChanListForThisChan ( 9  ); }
+    void OnReqConnClientsListCh0()  { CreateAndSendChanListForThisChan ( 0 ); }
+    void OnReqConnClientsListCh1()  { CreateAndSendChanListForThisChan ( 1 ); }
+    void OnReqConnClientsListCh2()  { CreateAndSendChanListForThisChan ( 2 ); }
+    void OnReqConnClientsListCh3()  { CreateAndSendChanListForThisChan ( 3 ); }
+    void OnReqConnClientsListCh4()  { CreateAndSendChanListForThisChan ( 4 ); }
+    void OnReqConnClientsListCh5()  { CreateAndSendChanListForThisChan ( 5 ); }
+    void OnReqConnClientsListCh6()  { CreateAndSendChanListForThisChan ( 6 ); }
+    void OnReqConnClientsListCh7()  { CreateAndSendChanListForThisChan ( 7 ); }
+    void OnReqConnClientsListCh8()  { CreateAndSendChanListForThisChan ( 8 ); }
+    void OnReqConnClientsListCh9()  { CreateAndSendChanListForThisChan ( 9 ); }
     void OnReqConnClientsListCh10() { CreateAndSendChanListForThisChan ( 10 ); }
     void OnReqConnClientsListCh11() { CreateAndSendChanListForThisChan ( 11 ); }
     void OnReqConnClientsListCh12() { CreateAndSendChanListForThisChan ( 12 ); }
@@ -434,6 +444,16 @@ public slots:
     void OnReqConnClientsListCh37() { CreateAndSendChanListForThisChan ( 37 ); }
     void OnReqConnClientsListCh38() { CreateAndSendChanListForThisChan ( 38 ); }
     void OnReqConnClientsListCh39() { CreateAndSendChanListForThisChan ( 39 ); }
+    void OnReqConnClientsListCh40() { CreateAndSendChanListForThisChan ( 30 ); }
+    void OnReqConnClientsListCh41() { CreateAndSendChanListForThisChan ( 41 ); }
+    void OnReqConnClientsListCh42() { CreateAndSendChanListForThisChan ( 42 ); }
+    void OnReqConnClientsListCh43() { CreateAndSendChanListForThisChan ( 43 ); }
+    void OnReqConnClientsListCh44() { CreateAndSendChanListForThisChan ( 44 ); }
+    void OnReqConnClientsListCh45() { CreateAndSendChanListForThisChan ( 45 ); }
+    void OnReqConnClientsListCh46() { CreateAndSendChanListForThisChan ( 46 ); }
+    void OnReqConnClientsListCh47() { CreateAndSendChanListForThisChan ( 47 ); }
+    void OnReqConnClientsListCh48() { CreateAndSendChanListForThisChan ( 48 ); }
+    void OnReqConnClientsListCh49() { CreateAndSendChanListForThisChan ( 49 ); }
 
     void OnChanInfoHasChangedCh0()  { CreateAndSendChanListForAllConChannels(); }
     void OnChanInfoHasChangedCh1()  { CreateAndSendChanListForAllConChannels(); }
@@ -475,6 +495,16 @@ public slots:
     void OnChanInfoHasChangedCh37() { CreateAndSendChanListForAllConChannels(); }
     void OnChanInfoHasChangedCh38() { CreateAndSendChanListForAllConChannels(); }
     void OnChanInfoHasChangedCh39() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh40() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh41() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh42() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh43() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh44() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh45() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh46() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh47() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh48() { CreateAndSendChanListForAllConChannels(); }
+    void OnChanInfoHasChangedCh49() { CreateAndSendChanListForAllConChannels(); }
 
     void OnChatTextReceivedCh0  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 0,  strChatText ); }
     void OnChatTextReceivedCh1  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 1,  strChatText ); }
@@ -516,17 +546,27 @@ public slots:
     void OnChatTextReceivedCh37 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 37, strChatText ); }
     void OnChatTextReceivedCh38 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 38, strChatText ); }
     void OnChatTextReceivedCh39 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 39, strChatText ); }
+    void OnChatTextReceivedCh40 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 40, strChatText ); }
+    void OnChatTextReceivedCh41 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 41, strChatText ); }
+    void OnChatTextReceivedCh42 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 42, strChatText ); }
+    void OnChatTextReceivedCh43 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 43, strChatText ); }
+    void OnChatTextReceivedCh44 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 44, strChatText ); }
+    void OnChatTextReceivedCh45 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 45, strChatText ); }
+    void OnChatTextReceivedCh46 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 46, strChatText ); }
+    void OnChatTextReceivedCh47 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 47, strChatText ); }
+    void OnChatTextReceivedCh48 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 48, strChatText ); }
+    void OnChatTextReceivedCh49 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 49, strChatText ); }
 
-    void OnServerAutoSockBufSizeChangeCh0  ( int iNNumFra ) { vecChannels[0].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh1  ( int iNNumFra ) { vecChannels[1].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh2  ( int iNNumFra ) { vecChannels[2].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh3  ( int iNNumFra ) { vecChannels[3].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh4  ( int iNNumFra ) { vecChannels[4].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh5  ( int iNNumFra ) { vecChannels[5].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh6  ( int iNNumFra ) { vecChannels[6].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh7  ( int iNNumFra ) { vecChannels[7].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh8  ( int iNNumFra ) { vecChannels[8].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh9  ( int iNNumFra ) { vecChannels[9].CreateJitBufMes  ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh0  ( int iNNumFra ) { vecChannels[0].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh1  ( int iNNumFra ) { vecChannels[1].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh2  ( int iNNumFra ) { vecChannels[2].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh3  ( int iNNumFra ) { vecChannels[3].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh4  ( int iNNumFra ) { vecChannels[4].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh5  ( int iNNumFra ) { vecChannels[5].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh6  ( int iNNumFra ) { vecChannels[6].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh7  ( int iNNumFra ) { vecChannels[7].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh8  ( int iNNumFra ) { vecChannels[8].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh9  ( int iNNumFra ) { vecChannels[9].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh10 ( int iNNumFra ) { vecChannels[10].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh11 ( int iNNumFra ) { vecChannels[11].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh12 ( int iNNumFra ) { vecChannels[12].CreateJitBufMes ( iNNumFra ); }
@@ -557,4 +597,15 @@ public slots:
     void OnServerAutoSockBufSizeChangeCh37 ( int iNNumFra ) { vecChannels[37].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh38 ( int iNNumFra ) { vecChannels[38].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh39 ( int iNNumFra ) { vecChannels[39].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh40 ( int iNNumFra ) { vecChannels[40].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh41 ( int iNNumFra ) { vecChannels[41].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh42 ( int iNNumFra ) { vecChannels[42].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh43 ( int iNNumFra ) { vecChannels[43].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh44 ( int iNNumFra ) { vecChannels[44].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh45 ( int iNNumFra ) { vecChannels[45].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh46 ( int iNNumFra ) { vecChannels[46].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh47 ( int iNNumFra ) { vecChannels[47].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh48 ( int iNNumFra ) { vecChannels[48].CreateJitBufMes ( iNNumFra ); }
+    void OnServerAutoSockBufSizeChangeCh49 ( int iNNumFra ) { vecChannels[49].CreateJitBufMes ( iNNumFra ); }
+
 };


### PR DESCRIPTION
Add support for up to 50 clients.
Wraps the mixer board in a QScrollArea so a horizontal scroll bar appears when more clients are connected than the window can display.