### PR TITLE
Enable scrolling for mixer board

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1143,6 +1143,8 @@ void CClientDlg::SetGUIDesign ( const EGUIDesign eNewDesign )
     switch ( eNewDesign )
     {
     case GD_ORIGINAL:
+        scrollAreaMixerBoard->setStyleSheet( "background: transparent;" );
+
         backgroundFrame->setStyleSheet (
             "QFrame#backgroundFrame { border-image:  url(:/png/fader/res/mixerboardbackground.png) 34px 30px 40px 40px;"
             "                         border-top:    34px transparent;"
@@ -1163,7 +1165,7 @@ void CClientDlg::SetGUIDesign ( const EGUIDesign eNewDesign )
             "QCheckBox::indicator:checked {"
             "                         image:          url(:/png/fader/res/ledbuttonpressed.png); }"
             "QCheckBox {              color:          rgb(148, 148, 148);"
-            "                         font:           bold; }" );            
+            "                         font:           bold; }" );
 
 #ifdef _WIN32
 // Workaround QT-Windows problem: This should not be necessary since in the
@@ -1180,7 +1182,9 @@ rbtReverbSelR->setStyleSheet ( "color: rgb(148, 148, 148);"
 
     default:
         // reset style sheet and set original paramters
+        scrollAreaMixerBoard->setStyleSheet( "" );
         backgroundFrame->setStyleSheet ( "" );
+
 
 #ifdef _WIN32
 // Workaround QT-Windows problem: See above description

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>345</width>
-    <height>363</height>
+    <width>800</width>
+    <height>350</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -568,13 +568,78 @@
        </layout>
       </item>
       <item>
-       <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <widget class="Line" name="lineMixerBoard">
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
         </property>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scrollAreaMixerBoard">
+        <property name="minimumSize">
+         <size>
+          <width>480</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaMixerBoardContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>480</width>
+           <height>323</height>
+          </rect>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Wraps the mixer board in a QScrollArea so a horizontal scroll bar appears when more clients are connected than the window can display.