### PR TITLE
Store mute settings for faders.

### DIFF
--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -53,11 +53,13 @@ public:
     void Hide() { pFrame->hide(); }
     bool IsVisible() { return plblLabel->isVisible(); }
     bool IsSolo() { return pcbSolo->isChecked(); }
+    bool IsMute() { return pcbMute->isChecked(); }
     void SetGUIDesign ( const EGUIDesign eNewDesign );
 
     void UpdateSoloState ( const bool bNewOtherSoloState );
     void SetFaderLevel ( const int iLevel );
     void SetFaderIsSolo ( const bool bIsSolo );
+    void SetFaderIsMute ( const bool bIsMute );
     int  GetFaderLevel() { return pFader->value(); }
     void Reset();
 
@@ -109,12 +111,15 @@ public:
     CVector<QString> vecStoredFaderTags;
     CVector<int>     vecStoredFaderLevels;
     CVector<int>     vecStoredFaderIsSolo;
+    CVector<int>     vecStoredFaderIsMute;
     int              iNewClientFaderLevel;
 
 protected:
     bool GetStoredFaderSettings ( const CChannelInfo& ChanInfo,
                                   int&                iStoredFaderLevel,
-                                  bool&               bStoredFaderIsSolo );
+                                  bool&               bStoredFaderIsSolo,
+                                  bool&               bStoredFaderIsMute );
+
     void StoreFaderSettings ( CChannelFader* pChanFader );
     void UpdateSoloStates();
 

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -98,7 +98,7 @@ void CChatDlg::AddChatText ( QString strChatText )
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
         txvChatWindow, 0, QAccessible::ValueChanged
 #else
-        new QAccessibleEvent ( txvChatWindow, QAccessible::ValueChanged )
+        new QAccessibleValueChangeEvent ( txvChatWindow, strChatText )
 #endif
         );
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -35,6 +35,7 @@ CClient::CClient ( const quint16  iPortNumber,
     vecStoredFaderTags               ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
     vecStoredFaderLevels             ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
     vecStoredFaderIsSolo             ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+    vecStoredFaderIsMute             ( MAX_NUM_STORED_FADER_SETTINGS, false ),
     iNewClientFaderLevel             ( 100 ),
     vecWindowPosMain                 (), // empty array
     vecWindowPosSettings             (), // empty array

--- a/src/client.h
+++ b/src/client.h
@@ -282,6 +282,7 @@ public:
     CVector<QString> vecStoredFaderTags;
     CVector<int>     vecStoredFaderLevels;
     CVector<int>     vecStoredFaderIsSolo;
+    CVector<int>     vecStoredFaderIsMute;
     int              iNewClientFaderLevel;
 
     // window position/state settings

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -189,6 +189,7 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     MainMixerBoard->vecStoredFaderTags   = pClient->vecStoredFaderTags;
     MainMixerBoard->vecStoredFaderLevels = pClient->vecStoredFaderLevels;
     MainMixerBoard->vecStoredFaderIsSolo = pClient->vecStoredFaderIsSolo;
+    MainMixerBoard->vecStoredFaderIsMute = pClient->vecStoredFaderIsMute;
     MainMixerBoard->iNewClientFaderLevel = pClient->iNewClientFaderLevel;
 
     // init status label
@@ -568,6 +569,7 @@ void CClientDlg::closeEvent ( QCloseEvent* Event )
     pClient->vecStoredFaderTags   = MainMixerBoard->vecStoredFaderTags;
     pClient->vecStoredFaderLevels = MainMixerBoard->vecStoredFaderLevels;
     pClient->vecStoredFaderIsSolo = MainMixerBoard->vecStoredFaderIsSolo;
+    pClient->vecStoredFaderIsMute = MainMixerBoard->vecStoredFaderIsMute;
     pClient->iNewClientFaderLevel = MainMixerBoard->iNewClientFaderLevel;
 
     // default implementation of this event handler routine

--- a/src/global.h
+++ b/src/global.h
@@ -165,7 +165,7 @@ LED bar:      lbr
 #define MAX_NUM_SERVER_ADDR_ITEMS       6
 
 // maximum number of fader settings to be stored (together with the fader tags)
-#define MAX_NUM_STORED_FADER_SETTINGS   70
+#define MAX_NUM_STORED_FADER_SETTINGS   200
 
 // defines for LED input level meter
 #define NUM_STEPS_INP_LEV_METER         8

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -88,6 +88,17 @@ void CSettings::Load()
             }
         }
 
+        // stored fader muted state
+        for ( iIdx = 0; iIdx < MAX_NUM_STORED_FADER_SETTINGS; iIdx++ )
+        {
+            if ( GetFlagIniSet ( IniXMLDocument, "client",
+                                 QString ( "storedfaderismute%1" ).arg ( iIdx ),
+                                 bValue ) )
+            {
+                pClient->vecStoredFaderIsMute[iIdx] = bValue;
+            }
+        }
+
         // new client level
         if ( GetNumericIniSet ( IniXMLDocument, "client", "newclientlevel",
              0, 100, iValue ) )
@@ -392,7 +403,15 @@ void CSettings::Save()
         {
             SetFlagIniSet ( IniXMLDocument, "client",
                             QString ( "storedfaderissolo%1" ).arg ( iIdx ),
-                            pClient->vecStoredFaderIsSolo[iIdx] != false );
+                            pClient->vecStoredFaderIsSolo[iIdx] != 0 );
+        }
+
+        // stored fader muted states
+        for ( iIdx = 0; iIdx < MAX_NUM_STORED_FADER_SETTINGS; iIdx++ )
+        {
+            SetFlagIniSet ( IniXMLDocument, "client",
+                            QString ( "storedfaderismute%1" ).arg ( iIdx ),
+                            pClient->vecStoredFaderIsMute[iIdx] != 0 );
         }
 
         // new client level


### PR DESCRIPTION
Also increase stored fader settings capacity to 200, since up to 50 clients are now supported.

I found this feature useful when singing with other people. We usually mute ourselves as we don't need to hear our own voice (slightly late) in the mix coming back from the server. It also prevents very noisy feedback if someone forgets to plug their headphones in before connecting to the server. By saving the mute settings, it's much easier to start a session and being ready to sing. Feel free to reject the pull request if you don't think this feature is useful in general.