### PR TITLE
Feature/channel meters

### DIFF
--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -36,6 +36,7 @@
 #include <QHostAddress>
 #include "global.h"
 #include "util.h"
+#include "multicolorledbar.h"
 
 
 /* Classes ********************************************************************/
@@ -54,12 +55,14 @@ public:
     bool IsVisible() { return plblLabel->isVisible(); }
     bool IsSolo() { return pcbSolo->isChecked(); }
     void SetGUIDesign ( const EGUIDesign eNewDesign );
+    void SetDisplayChannelLevel ( const bool eNDCL );
 
     void UpdateSoloState ( const bool bNewOtherSoloState );
     void SetFaderLevel ( const int iLevel );
     void SetFaderIsSolo ( const bool bIsSolo );
     int  GetFaderLevel() { return pFader->value(); }
     void Reset();
+    void SetChannelLevel ( const uint16_t iLevel );
 
 protected:
     double CalcFaderGain ( const int value );
@@ -67,18 +70,23 @@ protected:
     void   SendFaderLevelToServer ( const int iLevel );
     void   SetupFaderTag ( const ESkillLevel eSkillLevel );
 
-    QFrame*    pFrame;
-    QGroupBox* pLabelInstBox;
-    QSlider*   pFader;
-    QCheckBox* pcbMute;
-    QCheckBox* pcbSolo;
-    QLabel*    plblLabel;
-    QLabel*    plblInstrument;
-    QLabel*    plblCountryFlag;
+    QFrame*            pFrame;
 
-    QString    strReceivedName;
+    QWidget*           pLevelsBox;
+    CMultiColorLEDBar* plbrChannelLevel;
+    QSlider*           pFader;
 
-    bool       bOtherChannelIsSolo;
+    QCheckBox*         pcbMute;
+    QCheckBox*         pcbSolo;
+
+    QGroupBox*         pLabelInstBox;
+    QLabel*            plblLabel;
+    QLabel*            plblInstrument;
+    QLabel*            plblCountryFlag;
+
+    QString            strReceivedName;
+
+    bool               bOtherChannelIsSolo;
 
 public slots:
     void OnLevelValueChanged ( int value ) { SendFaderLevelToServer ( value ); }
@@ -101,9 +109,12 @@ public:
     void ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInfo );
     void SetServerName ( const QString& strNewServerName );
     void SetGUIDesign ( const EGUIDesign eNewDesign );
+    void SetDisplayChannelLevels ( const bool eNDCL );
 
     void SetFaderLevel ( const int iChannelIdx,
                          const int iValue );
+
+    void SetChannelLevels ( const CVector<uint16_t>& vecChannelLevel );
 
     // settings
     CVector<QString> vecStoredFaderTags;
@@ -124,6 +135,7 @@ protected:
     CVector<CChannelFader*> vecpChanFader;
     QGroupBox*              pGroupBox;
     QHBoxLayout*            pMainLayout;
+    bool                    bDisplayChannelLevels;
     bool                    bNoFaderVisible;
 
 public slots:

--- a/src/channel.h
+++ b/src/channel.h
@@ -165,6 +165,12 @@ public:
 
     CNetworkTransportProps GetNetworkTransportPropsFromCurrentSettings();
 
+    bool ChannelLevelsRequired() const                { return bChannelLevelsRequired; }
+    void SetChannelLevelsRequired ( const bool nCLR ) { bChannelLevelsRequired = nCLR; }
+
+    double GetPrevLevel() const              { return dPrevLevel; }
+    void   SetPrevLevel ( const double nPL ) { dPrevLevel = nPL; }
+
 protected:
     bool ProtocolIsEnabled();
 
@@ -177,6 +183,8 @@ protected:
         iNetwFrameSizeFact    = FRAME_SIZE_FACTOR_PREFERRED;
         iNetwFrameSize        = CELT_MINIMUM_NUM_BYTES;
         iNumAudioChannels     = 1; // mono
+
+        dPrevLevel            = 0.0;
     }
 
     // connection parameters
@@ -215,6 +223,9 @@ protected:
     QMutex            Mutex;
     QMutex            MutexSocketBuf;
     QMutex            MutexConvBuf;
+
+    bool              bChannelLevelsRequired;
+    double            dPrevLevel;
 
 public slots:
     void OnSendProtMessage ( CVector<uint8_t> vecMessage );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,6 +64,7 @@ CClient::CClient ( const quint16  iPortNumber,
     bFraSiFactDefSupported           ( false ),
     bFraSiFactSafeSupported          ( false ),
     eGUIDesign                       ( GD_ORIGINAL ),
+    bDisplayChannelLevels            ( false ),
     bJitterBufferOK                  ( true ),
     strCentralServerAddress          ( "" ),
     bUseDefaultCentralServerAddress  ( true ),
@@ -278,6 +279,9 @@ void CClient::OnNewConnection()
     // Same problem is with the jitter buffer message.
     Channel.CreateReqConnClientsList();
     CreateServerJitterBufferMessage();
+
+    // send opt-in / out for Channel Level updates
+    SetDisplayChannelLevels ( bDisplayChannelLevels );
 }
 
 void CClient::CreateServerJitterBufferMessage()
@@ -384,6 +388,14 @@ bool CClient::GetAndResetbJitterBufferOKFlag()
     // since per definition the jitter buffer status is OK if both the
     // put and get status are OK
     return bSocketJitBufOKFlag;
+}
+
+void CClient::SetDisplayChannelLevels ( const bool bNDCL )
+{
+    bDisplayChannelLevels = bNDCL;
+
+    // tell any connected server about the change
+    ConnLessProtocol.CreateCLReqChannelLevelListMes ( Channel.GetAddress(), bNDCL );
 }
 
 void CClient::SetSndCrdPrefFrameSizeFactor ( const int iNewFactor )

--- a/src/client.h
+++ b/src/client.h
@@ -111,7 +111,8 @@ public:
     CClient ( const quint16  iPortNumber,
               const QString& strConnOnStartupAddress,
               const int      iCtrlMIDIChannel,
-              const bool     bNoAutoJackConnect );
+              const bool     bNoAutoJackConnect,
+              QTextStream&   tsNC );
 
     void   Start();
     void   Stop();
@@ -315,6 +316,7 @@ protected:
     int         EvaluatePingMessage ( const int iMs );
     void        CreateServerJitterBufferMessage();
 
+    QTextStream&            tsConsole;
     // only one channel is needed for client application
     CChannel                Channel;
     CProtocol               ConnLessProtocol;
@@ -401,6 +403,9 @@ public slots:
 
     void OnSndCrdReinitRequest ( int iSndCrdResetType );
 
+    void OnCLChannelLevelListReceived ( CHostAddress      InetAddr,
+                                        CVector<uint16_t> vecLevelList );
+
 signals:
     void ConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );
     void ChatTextReceived ( QString strChatText );
@@ -422,6 +427,9 @@ signals:
                                   COSUtil::EOpSystemType eOSType,
                                   QString                strVersion );
 #endif
+
+    void CLChannelLevelListReceived ( CHostAddress      InetAddr,
+                                      CVector<uint16_t> vecLevelList );
 
     void Disconnected();
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );

--- a/src/client.h
+++ b/src/client.h
@@ -128,6 +128,9 @@ public:
     EGUIDesign GetGUIDesign() const { return eGUIDesign; }
     void SetGUIDesign ( const EGUIDesign eNGD ) { eGUIDesign = eNGD; }
 
+    bool GetDisplayChannelLevels() const { return bDisplayChannelLevels; }
+    void SetDisplayChannelLevels ( const bool bNDCL );
+
     EAudioQuality GetAudioQuality() const { return eAudioQuality; }
     void SetAudioQuality ( const EAudioQuality eNAudioQuality );
 
@@ -358,6 +361,7 @@ protected:
     int                     iStereoBlockSizeSam;
 
     EGUIDesign              eGUIDesign;
+    bool                    bDisplayChannelLevels;
 
     bool                    bJitterBufferOK;
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -485,6 +485,10 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
         SIGNAL ( ControllerInFaderLevel ( int, int ) ),
         this, SLOT ( OnControllerInFaderLevel ( int, int ) ) );
 
+    QObject::connect ( pClient,
+        SIGNAL ( CLChannelLevelListReceived ( CHostAddress, CVector<uint16_t> ) ),
+        this, SLOT ( OnCLChannelLevelListReceived ( CHostAddress, CVector<uint16_t> ) ) );
+
 #ifdef ENABLE_CLIENT_VERSION_AND_OS_DEBUGGING
     QObject::connect ( pClient,
         SIGNAL ( CLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType, QString ) ),

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -185,6 +185,9 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     // reset mixer board
     MainMixerBoard->HideAll();
 
+    // restore channel level display preference
+    MainMixerBoard->SetDisplayChannelLevels ( pClient->GetDisplayChannelLevels() );
+
     // restore fader settings
     MainMixerBoard->vecStoredFaderTags   = pClient->vecStoredFaderTags;
     MainMixerBoard->vecStoredFaderLevels = pClient->vecStoredFaderLevels;
@@ -493,6 +496,9 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
 
     QObject::connect ( &ClientSettingsDlg, SIGNAL ( GUIDesignChanged() ),
         this, SLOT ( OnGUIDesignChanged() ) );
+
+    QObject::connect ( &ClientSettingsDlg, SIGNAL ( DisplayChannelLevelsChanged() ),
+        this, SLOT ( OnDisplayChannelLevelsChanged() ) );
 
     QObject::connect ( &ClientSettingsDlg, SIGNAL ( AudioChannelsChanged() ),
         this, SLOT ( OnAudioChannelsChanged() ) );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -904,7 +904,7 @@ void CClientDlg::OnTimerSigMet()
     // linear transformation of the input level range to the progress-bar
     // range
     dCurSigLevelL -= LOW_BOUND_SIG_METER;
-    dCurSigLevelL *= NUM_STEPS_INP_LEV_METER /
+    dCurSigLevelL *= NUM_STEPS_LED_BAR /
         ( UPPER_BOUND_SIG_METER - LOW_BOUND_SIG_METER );
 
     // lower bound the signal
@@ -914,7 +914,7 @@ void CClientDlg::OnTimerSigMet()
     }
 
     dCurSigLevelR -= LOW_BOUND_SIG_METER;
-    dCurSigLevelR *= NUM_STEPS_INP_LEV_METER /
+    dCurSigLevelR *= NUM_STEPS_LED_BAR /
         ( UPPER_BOUND_SIG_METER - LOW_BOUND_SIG_METER );
 
     // lower bound the signal

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -198,6 +198,9 @@ public slots:
     void OnGUIDesignChanged()
         { SetGUIDesign ( pClient->GetGUIDesign() ); }
 
+    void OnDisplayChannelLevelsChanged()
+        { MainMixerBoard->SetDisplayChannelLevels ( pClient->GetDisplayChannelLevels() ); }
+
     void OnAudioChannelsChanged() { UpdateRevSelection(); }
     void OnNumClientsChanged ( int iNewNumClients );
     void OnNewClientLevelChanged() { MainMixerBoard->iNewClientFaderLevel = pClient->iNewClientFaderLevel; }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -192,6 +192,10 @@ public slots:
                                           CVector<CChannelInfo> vecChanInfo )
         { ConnectDlg.SetConnClientsList ( InetAddr, vecChanInfo ); }
 
+    void OnCLChannelLevelListReceived ( CHostAddress       /* unused */,
+                                        CVector<uint16_t> vecLevelList )
+        { MainMixerBoard->SetChannelLevels ( vecLevelList ); }
+
     void OnConnectDlgAccepted();
     void OnDisconnected();
 

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -60,10 +60,6 @@
 #define BUFFER_LED_UPDATE_TIME_MS   300   // ms
 #define LED_BAR_UPDATE_TIME_MS      1000  // ms
 
-// range for signal level meter
-#define LOW_BOUND_SIG_METER         ( -50.0 ) // dB
-#define UPPER_BOUND_SIG_METER       ( 0.0 )   // dB
-
 // number of ping times > upper bound until error message is shown
 #define NUM_HIGH_PINGS_UNTIL_ERROR  5
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -189,6 +189,12 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, QWidget* parent,
 
     chbGUIDesignFancy->setAccessibleName ( tr ( "Fancy skin check box" ) );
 
+    // display channel levels
+    chbDisplayChannelLevels->setWhatsThis ( tr ( "<b>Display Channel Levels:</b> "
+        "If enabled, each client channel will display a pre-fader level bar." ) );
+
+    chbDisplayChannelLevels->setAccessibleName ( tr ( "Display channel levels check box" ) );
+
     // audio channels
     QString strAudioChannels = tr ( "<b>Audio Channels:</b> "
         "Select the number of audio channels to be used. There are three "
@@ -323,6 +329,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, QWidget* parent,
         chbGUIDesignFancy->setCheckState ( Qt::Checked );
     }
 
+    //  Display Channel Levels check box
+    chbDisplayChannelLevels->setCheckState ( pClient->GetDisplayChannelLevels() ? Qt::Checked : Qt::Unchecked );
+
     // "Audio Channels" combo box
     cbxAudioChannels->clear();
     cbxAudioChannels->addItem ( "Mono" );               // CC_MONO
@@ -385,6 +394,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, QWidget* parent,
     // check boxes
     QObject::connect ( chbGUIDesignFancy, SIGNAL ( stateChanged ( int ) ),
         this, SLOT ( OnGUIDesignFancyStateChanged ( int ) ) );
+
+    QObject::connect ( chbDisplayChannelLevels, SIGNAL ( stateChanged ( int ) ),
+        this, SLOT ( OnDisplayChannelLevelsStateChanged ( int ) ) );
 
     QObject::connect ( chbAutoJitBuf, SIGNAL ( stateChanged ( int ) ),
         this, SLOT ( OnAutoJitBufStateChanged ( int ) ) );
@@ -702,6 +714,12 @@ void CClientSettingsDlg::OnGUIDesignFancyStateChanged ( int value )
     }
     emit GUIDesignChanged();
     UpdateDisplay();
+}
+
+void CClientSettingsDlg::OnDisplayChannelLevelsStateChanged ( int value )
+{
+    pClient->SetDisplayChannelLevels ( value != Qt::Unchecked );
+    emit DisplayChannelLevelsChanged();
 }
 
 void CClientSettingsDlg::OnDefaultCentralServerStateChanged ( int value )

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -90,6 +90,7 @@ protected:
     void OnSliderSndCrdBufferDelay ( int value );
     void OnAutoJitBufStateChanged ( int value );
     void OnGUIDesignFancyStateChanged ( int value );
+    void OnDisplayChannelLevelsStateChanged ( int value );
     void OnDefaultCentralServerStateChanged ( int value );
     void OnCentralServerAddressEditingFinished();
     void OnNewClientLevelEditingFinished();
@@ -105,6 +106,7 @@ protected:
 
 signals:
     void GUIDesignChanged();
+    void DisplayChannelLevelsChanged();
     void AudioChannelsChanged();
     void NewClientLevelChanged();
 };

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -530,11 +530,22 @@
        </layout>
       </item>
       <item>
-       <widget class="QCheckBox" name="chbGUIDesignFancy">
-        <property name="text">
-         <string>Fancy Skin</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout">
+        <item>
+         <widget class="QCheckBox" name="chbGUIDesignFancy">
+          <property name="text">
+           <string>Fancy Skin</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="chbDisplayChannelLevels">
+          <property name="text">
+           <string>Display Channel Levels</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <layout class="QHBoxLayout">
@@ -719,6 +730,7 @@
   <tabstop>cbxAudioQuality</tabstop>
   <tabstop>edtNewClientLevel</tabstop>
   <tabstop>chbGUIDesignFancy</tabstop>
+  <tabstop>chbDisplayChannelFaders</tabstop>
   <tabstop>chbDefaultCentralServer</tabstop>
   <tabstop>edtCentralServerAddress</tabstop>
  </tabstops>

--- a/src/global.h
+++ b/src/global.h
@@ -167,10 +167,14 @@ LED bar:      lbr
 // maximum number of fader settings to be stored (together with the fader tags)
 #define MAX_NUM_STORED_FADER_SETTINGS   70
 
-// defines for LED input level meter
-#define NUM_STEPS_INP_LEV_METER         8
-#define RED_BOUND_INP_LEV_METER         7
-#define YELLOW_BOUND_INP_LEV_METER      5
+// defines for LED level meter CMultiColorLEDBar
+#define NUM_STEPS_LED_BAR               8
+#define RED_BOUND_LED_BAR               7
+#define YELLOW_BOUND_LED_BAR            5
+
+// range for signal level meter
+#define LOW_BOUND_SIG_METER         ( -50.0 ) // dB
+#define UPPER_BOUND_SIG_METER       ( 0.0 )   // dB
 
 // Maximum number of connected clients at the server. If you want to change this
 // paramter you have to modify the code on some places, too! The code tag

--- a/src/global.h
+++ b/src/global.h
@@ -197,6 +197,9 @@ LED bar:      lbr
 // list
 #define PING_UPDATE_TIME_SERVER_LIST_MS 2000 // ms
 
+// defines the interval between Channel Level updates from the server
+#define CHANNEL_LEVEL_UPDATE_INTERVAL   100  // number of frames
+
 // time-out until a registered server is deleted from the server list if no
 // new registering was made in minutes
 #define SERVLIST_TIME_OUT_MINUTES       60 // minutes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -482,7 +482,8 @@ int main ( int argc, char** argv )
             CClient Client ( iPortNumber,
                              strConnOnStartupAddress,
                              iCtrlMIDIChannel,
-                             bNoAutoJackConnect );
+                             bNoAutoJackConnect,
+                             tsConsole );
 
             // load settings from init-file
             CSettings Settings ( &Client, strIniFileName );

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -33,7 +33,7 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f )
     : QFrame ( parent, f )
 {
     // set total number of LEDs
-    iNumLEDs = NUM_STEPS_INP_LEV_METER;
+    iNumLEDs = NUM_STEPS_LED_BAR;
 
     // create layout and set spacing to zero
     pMainLayout = new QVBoxLayout ( this );
@@ -105,14 +105,14 @@ void CMultiColorLEDBar::setValue ( const int value )
             if ( iLEDIdx < value )
             {
                 // check which color we should use (green, yellow or red)
-                if ( iLEDIdx < YELLOW_BOUND_INP_LEV_METER )
+                if ( iLEDIdx < YELLOW_BOUND_LED_BAR )
                 {
                     // green region
                     vecpLEDs[iLEDIdx]->setColor ( cLED::RL_GREEN );
                 }
                 else
                 {
-                    if ( iLEDIdx < RED_BOUND_INP_LEV_METER )
+                    if ( iLEDIdx < RED_BOUND_LED_BAR )
                     {
                         // yellow region
                         vecpLEDs[iLEDIdx]->setColor ( cLED::RL_YELLOW );

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -270,6 +270,35 @@ CONNECTION LESS MESSAGES
 
     note: does not have any data -> n = 0
 
+- PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST: Opt in or out of the channel level list
+
+    +---------------+
+    | 1 byte option |
+    +---------------+
+
+    option is boolean, true to opt in, false to opt out
+
+- PROTMESSID_CLM_CHANNEL_LEVEL_LIST: The channel level list
+
+    +----------------------------------+
+    | ( ( n + 1 ) / 2 ) * 4 bit values |
+    +----------------------------------+
+
+    n is number of connected clients
+
+    the values are the maximum channel levels for a client frame converted
+    to the range of CMultiColorLEDBar in 4 bits, two entries per byte
+    with the earlier channel in the lower half of the byte
+
+    where an odd number of clients is connected, there will be four unused
+    upper bits in the final byte, containing 0xF (which is out of range)
+
+    the server may compute them message when any client has used
+    PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST to opt in
+
+    the server may issue to message only to a client that has used
+    PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST to opt in
+
 
  ******************************************************************************
  *
@@ -293,7 +322,8 @@ CONNECTION LESS MESSAGES
 
 
 /* Implementation *************************************************************/
-CProtocol::CProtocol()
+CProtocol::CProtocol ( QTextStream& tsNC ) :
+    tsConsole ( tsNC )
 {
     Reset();
 
@@ -627,6 +657,14 @@ if ( rand() < ( RAND_MAX / 2 ) ) return false;
 
         case PROTMESSID_CLM_REQ_CONN_CLIENTS_LIST:
             bRet = EvaluateCLReqConnClientsListMes ( InetAddr );
+            break;
+
+        case PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST:
+            bRet = EvaluateCLReqChannelLevelListMes ( InetAddr, vecbyMesBodyData );
+            break;
+
+        case PROTMESSID_CLM_CHANNEL_LEVEL_LIST:
+            bRet = EvaluateCLChannelLevelListMes ( InetAddr, vecbyMesBodyData );
             break;
         }
     }
@@ -1920,6 +1958,89 @@ bool CProtocol::EvaluateCLReqConnClientsListMes ( const CHostAddress& InetAddr )
 {
     // invoke message action
     emit CLReqConnClientsList ( InetAddr );
+
+    return false; // no error
+}
+
+void CProtocol::CreateCLReqChannelLevelListMes ( const CHostAddress& InetAddr,
+                                                 const bool          bRCL )
+{
+    CVector<uint8_t> vecData ( 1 );
+    int              iPos = 0; // init position pointer
+    PutValOnStream ( vecData, iPos,
+        static_cast<uint32_t> ( bRCL ), 1 );
+
+    CreateAndImmSendConLessMessage ( PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST,
+                                     vecData,
+                                     InetAddr );
+}
+
+bool CProtocol::EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr,
+                                                   const CVector<uint8_t>& vecData )
+{
+    int iPos = 0; // init position pointer
+
+    // invoke message action
+    emit CLReqChannelLevelList ( InetAddr, GetValFromStream ( vecData, iPos, 1 ) != 0 );
+
+    return false; // no error
+}
+
+void CProtocol::CreateCLChannelLevelListMes  ( const CHostAddress&      InetAddr,
+                                               const CVector<uint16_t>& vecLevelList,
+                                               const int                iNumClients )
+{
+    // This must be a multiple of bytes at four bits per client
+    const int        iNumBytes = ( iNumClients + 1 ) / 2;
+    CVector<uint8_t> vecData( iNumBytes );
+    int              iPos = 0; // init position pointer
+
+    for ( int i = 0, j = 0; i < iNumClients; i += 2 /* pack two per byte */, j++ )
+    {
+        uint16_t levelLo = vecLevelList[i] & 0x0F;
+        uint16_t levelHi = ( i + 1 < iNumClients ) ? vecLevelList[i + 1] & 0x0F : 0x0F;
+        uint8_t  byte    = static_cast<uint8_t> ( levelLo | ( levelHi << 4 ) );
+
+        PutValOnStream ( vecData, iPos,
+            static_cast<uint32_t> ( byte ), 1 );
+    }
+
+    CreateAndImmSendConLessMessage ( PROTMESSID_CLM_CHANNEL_LEVEL_LIST,
+                                     vecData,
+                                     InetAddr );
+}
+
+bool CProtocol::EvaluateCLChannelLevelListMes  ( const CHostAddress&     InetAddr,
+                                                 const CVector<uint8_t>& vecData )
+{
+    int       iPos     = 0; // init position pointer
+    const int iDataLen = vecData.Size();  // four bits per channel, 2 channels per byte
+                                          // may have one too many entries, last being 0xF
+    int       iVecLen  = iDataLen * 2; // one ushort per channel
+
+    CVector<uint16_t> vecLevelList ( iVecLen );
+
+    for (int i = 0, j = 0; i < iDataLen; i++, j += 2 )
+    {
+        uint8_t  byte    = static_cast<uint8_t> ( GetValFromStream ( vecData, iPos, 1 ) );
+        uint16_t levelLo = byte & 0x0F;
+        uint16_t levelHi = ( byte >> 4 ) & 0x0F;
+
+        vecLevelList[j]     = levelLo;
+
+        if ( levelHi != 0x0F )
+        {
+            vecLevelList[j + 1] = levelHi;
+        }
+        else
+        {
+            vecLevelList.resize ( iVecLen - 1 );
+            break;
+        }
+    }
+
+    // invoke message action
+    emit CLChannelLevelListReceived ( InetAddr, vecLevelList );
 
     return false; // no error
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -71,6 +71,8 @@
 #define PROTMESSID_CLM_REQ_VERSION_AND_OS     1012 // request version number and operating system
 #define PROTMESSID_CLM_CONN_CLIENTS_LIST      1013 // channel infos for connected clients
 #define PROTMESSID_CLM_REQ_CONN_CLIENTS_LIST  1014 // request the connected clients list
+#define PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST 1015 // request the channel level list
+#define PROTMESSID_CLM_CHANNEL_LEVEL_LIST     1016 // channel level list
 
 // lengths of message as defined in protocol.cpp file
 #define MESS_HEADER_LENGTH_BYTE         7 // TAG (2), ID (2), cnt (1), length (2)
@@ -86,7 +88,7 @@ class CProtocol : public QObject
     Q_OBJECT
 
 public:
-    CProtocol();
+    CProtocol( QTextStream& tsNC = *( ( new ConsoleWriterFactory() )->get() ));
 
     void Reset();
 
@@ -102,26 +104,31 @@ public:
     void CreateReqNetwTranspPropsMes();
     void CreateLicenceRequiredMes ( const ELicenceType eLicenceType );
 
-    void CreateCLPingMes               ( const CHostAddress& InetAddr, const int iMs );
-    void CreateCLPingWithNumClientsMes ( const CHostAddress& InetAddr,
-                                         const int           iMs,
-                                         const int           iNumClients );
-    void CreateCLServerFullMes         ( const CHostAddress& InetAddr );
-    void CreateCLRegisterServerMes     ( const CHostAddress&    InetAddr,
-                                         const CServerCoreInfo& ServerInfo );
-    void CreateCLUnregisterServerMes   ( const CHostAddress& InetAddr );
-    void CreateCLServerListMes         ( const CHostAddress&        InetAddr,
-                                         const CVector<CServerInfo> vecServerInfo );
-    void CreateCLReqServerListMes      ( const CHostAddress& InetAddr );
-    void CreateCLSendEmptyMesMes       ( const CHostAddress& InetAddr,
-                                         const CHostAddress& TargetInetAddr );
-    void CreateCLEmptyMes              ( const CHostAddress& InetAddr );
-    void CreateCLDisconnection         ( const CHostAddress& InetAddr );
-    void CreateCLVersionAndOSMes       ( const CHostAddress& InetAddr );
-    void CreateCLReqVersionAndOSMes    ( const CHostAddress& InetAddr );
-    void CreateCLConnClientsListMes    ( const CHostAddress&          InetAddr,
-                                         const CVector<CChannelInfo>& vecChanInfo );
-    void CreateCLReqConnClientsListMes ( const CHostAddress& InetAddr );
+    void CreateCLPingMes                 ( const CHostAddress& InetAddr, const int iMs );
+    void CreateCLPingWithNumClientsMes   ( const CHostAddress& InetAddr,
+                                           const int           iMs,
+                                           const int           iNumClients );
+    void CreateCLServerFullMes           ( const CHostAddress& InetAddr );
+    void CreateCLRegisterServerMes       ( const CHostAddress&    InetAddr,
+                                           const CServerCoreInfo& ServerInfo );
+    void CreateCLUnregisterServerMes     ( const CHostAddress& InetAddr );
+    void CreateCLServerListMes           ( const CHostAddress&        InetAddr,
+                                           const CVector<CServerInfo> vecServerInfo );
+    void CreateCLReqServerListMes        ( const CHostAddress& InetAddr );
+    void CreateCLSendEmptyMesMes         ( const CHostAddress& InetAddr,
+                                           const CHostAddress& TargetInetAddr );
+    void CreateCLEmptyMes                ( const CHostAddress& InetAddr );
+    void CreateCLDisconnection           ( const CHostAddress& InetAddr );
+    void CreateCLVersionAndOSMes         ( const CHostAddress& InetAddr );
+    void CreateCLReqVersionAndOSMes      ( const CHostAddress& InetAddr );
+    void CreateCLConnClientsListMes      ( const CHostAddress&          InetAddr,
+                                           const CVector<CChannelInfo>& vecChanInfo );
+    void CreateCLReqConnClientsListMes   ( const CHostAddress& InetAddr );
+    void CreateCLReqChannelLevelListMes  ( const CHostAddress& InetAddr,
+                                           const bool          bRCL );
+    void CreateCLChannelLevelListMes     ( const CHostAddress&      InetAddr,
+                                           const CVector<uint16_t>& vecLevelList,
+                                           const int                iNumClients );
 
     static bool ParseMessageFrame ( const CVector<uint8_t>& vecbyData,
                                     const int               iNumBytesIn,
@@ -216,25 +223,29 @@ protected:
     bool EvaluateReqNetwTranspPropsMes();
     bool EvaluateLicenceRequiredMes   ( const CVector<uint8_t>& vecData );
 
-    bool EvaluateCLPingMes               ( const CHostAddress&     InetAddr,
-                                           const CVector<uint8_t>& vecData );
-    bool EvaluateCLPingWithNumClientsMes ( const CHostAddress&     InetAddr,
-                                           const CVector<uint8_t>& vecData );
+    bool EvaluateCLPingMes                 ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
+    bool EvaluateCLPingWithNumClientsMes   ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
     bool EvaluateCLServerFullMes();
-    bool EvaluateCLRegisterServerMes     ( const CHostAddress&     InetAddr,
-                                           const CVector<uint8_t>& vecData );
-    bool EvaluateCLUnregisterServerMes   ( const CHostAddress&     InetAddr );
-    bool EvaluateCLServerListMes         ( const CHostAddress&     InetAddr,
-                                           const CVector<uint8_t>& vecData );
-    bool EvaluateCLReqServerListMes      ( const CHostAddress&     InetAddr );
-    bool EvaluateCLSendEmptyMesMes       ( const CVector<uint8_t>& vecData );
-    bool EvaluateCLDisconnectionMes      ( const CHostAddress&     InetAddr );
-    bool EvaluateCLVersionAndOSMes       ( const CHostAddress&     InetAddr,
-                                           const CVector<uint8_t>& vecData );
-    bool EvaluateCLReqVersionAndOSMes    ( const CHostAddress&     InetAddr );
-    bool EvaluateCLConnClientsListMes    ( const CHostAddress&     InetAddr,
-                                           const CVector<uint8_t>& vecData );
-    bool EvaluateCLReqConnClientsListMes ( const CHostAddress&     InetAddr );
+    bool EvaluateCLRegisterServerMes       ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
+    bool EvaluateCLUnregisterServerMes     ( const CHostAddress&     InetAddr );
+    bool EvaluateCLServerListMes           ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
+    bool EvaluateCLReqServerListMes        ( const CHostAddress&     InetAddr );
+    bool EvaluateCLSendEmptyMesMes         ( const CVector<uint8_t>& vecData );
+    bool EvaluateCLDisconnectionMes        ( const CHostAddress&     InetAddr );
+    bool EvaluateCLVersionAndOSMes         ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
+    bool EvaluateCLReqVersionAndOSMes      ( const CHostAddress&     InetAddr );
+    bool EvaluateCLConnClientsListMes      ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
+    bool EvaluateCLReqConnClientsListMes   ( const CHostAddress&     InetAddr );
+    bool EvaluateCLReqChannelLevelListMes  ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
+    bool EvaluateCLChannelLevelListMes     ( const CHostAddress&     InetAddr,
+                                             const CVector<uint8_t>& vecData );
 
     int                     iOldRecID;
     int                     iOldRecCnt;
@@ -245,6 +256,8 @@ protected:
 
     QTimer                  TimerSendMess;
     QMutex                  Mutex;
+
+    QTextStream&            tsConsole;
 
 public slots:
     void OnTimerSendMess() { SendMessage(); }
@@ -290,4 +303,8 @@ signals:
     void CLConnClientsListMesReceived ( CHostAddress           InetAddr,
                                         CVector<CChannelInfo>  vecChanInfo );
     void CLReqConnClientsList         ( CHostAddress           InetAddr );
+    void CLReqChannelLevelList        ( CHostAddress           InetAddr,
+                                        bool                   bSetting );
+    void CLChannelLevelListReceived   ( CHostAddress           InetAddr,
+                                        CVector<uint16_t>      vecLevelList );
 };

--- a/src/server.h
+++ b/src/server.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <QDateTime>
 #include <QHostAddress>
+#include <algorithm>
 #ifdef USE_OPUS_SHARED_LIB
 # include "opus/opus_custom.h"
 #else
@@ -220,6 +221,11 @@ protected:
 
     virtual void customEvent ( QEvent* pEvent );
 
+    void CreateLevelsForAllConChannels  ( const int                        iNumClients,
+                                          const CVector<int>&              vecNumAudioChannels,
+                                          const CVector<CVector<int16_t> > vecvecsData,
+                                          CVector<uint16_t>&               vecLevelsOut );
+
     // do not use the vector class since CChannel does not have appropriate
     // copy constructor/operator
     CChannel                   vecChannels[MAX_NUM_CHANNELS];
@@ -243,11 +249,17 @@ protected:
     CVector<int16_t>           vecsSendData;
     CVector<uint8_t>           vecbyCodedData;
 
+    // Channel levels
+    CVector<uint16_t>          vecChannelLevels;
+
     // actual working objects
     CHighPrioSocket            Socket;
 
     // logging
     CServerLogging             Logging;
+
+    // channel level update frame interval counter
+    uint16_t                   iFrameCount;
 
     // recording thread
     recorder::CJamRecorder     JamRecorder;
@@ -335,6 +347,8 @@ public slots:
 
     void OnCLReqConnClientsList ( CHostAddress InetAddr )
         { ConnLessProtocol.CreateCLConnClientsListMes ( InetAddr, CreateChannelList() ); }
+
+    void OnCLReqChannelLevelList ( CHostAddress InetAddr, bool bSetting );
 
     void OnCLRegisterServerReceived ( CHostAddress    InetAddr,
                                       CServerCoreInfo ServerInfo )

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -239,6 +239,12 @@ void CSettings::Load()
             pClient->SetGUIDesign ( static_cast<EGUIDesign> ( iValue ) );
         }
 
+        // display channel levels preference
+        if ( GetFlagIniSet ( IniXMLDocument, "client", "displaychannellevels", bValue ) )
+        {
+            pClient->SetDisplayChannelLevels ( bValue );
+        }
+
         // audio channels
         if ( GetNumericIniSet ( IniXMLDocument, "client", "audiochannels",
              0, 2 /* CC_STEREO */, iValue ) )
@@ -470,6 +476,10 @@ void CSettings::Save()
         // GUI design
         SetNumericIniSet ( IniXMLDocument, "client", "guidesign",
             static_cast<int> ( pClient->GetGUIDesign() ) );
+
+        // display channel levels preference
+        SetFlagIniSet ( IniXMLDocument, "client", "displaychannellevels",
+            pClient->GetDisplayChannelLevels() );
 
         // audio channels
         SetNumericIniSet ( IniXMLDocument, "client", "audiochannels",


### PR DESCRIPTION
OK, I've reworked the commits into a nice clean series.

I've tested locally with two clients, both supporting the channel levels.  Each can see the levels, when they want to, for the client transmitting audio.

This version isn't compatible with the previous version!  (4 bits per channel now.)

I've a remaining concern over what happens on a busier server where server channels and clients are changing a lot (so you could get a new client joining on channel 0 or only channels 0 and 4 being in use) - I'm not quite sure what happens then.  I don't remember clearly whether I tested that yet - I'll give it a go tomorrow (with two clients where the earlier joining one disconnects).