### PR TITLE
Multichannel CoreAudio Support

### DIFF
--- a/mac/sound.cpp
+++ b/mac/sound.cpp
@@ -276,7 +276,6 @@ int CSound::CountChannels(AudioDeviceID devID, bool isInput)
         for (UInt32 i = 0; i < buflist->mNumberBuffers; ++i) {
             result += buflist->mBuffers[i].mNumberChannels;
         }
-        qDebug() << "Input buffer count is " << buflist->mNumberBuffers;
     }
     free(buflist);
     return result;
@@ -824,7 +823,6 @@ OSStatus CSound::callbackIO ( AudioDeviceID          inDevice,
                 
                 // right
                 pSound->vecsTmpAudioSndCrdStereo[2 * i + 1] = (short) ( pRightData[i] * _MAXSHORT );
-                qDebug() << *pLeftData << ":" << *pRightData;
             }
         } else if ( inInputData->mBuffers[0].mDataByteSize ==
              static_cast<UInt32> ( iCoreAudioBufferSizeMono * iNumInChan * 4 ) )
@@ -848,7 +846,6 @@ OSStatus CSound::callbackIO ( AudioDeviceID          inDevice,
         else
         {
             // incompatible sizes, clear work buffer
-            qDebug("Incompatible data");
             pSound->vecsTmpAudioSndCrdStereo.Reset ( 0 );
         }
 

--- a/mac/sound.h
+++ b/mac/sound.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <CoreAudio/CoreAudio.h>
+#include <AudioToolbox/AudioToolbox.h>
 #include <CoreMIDI/CoreMIDI.h>
 #include <QMutex>
 #include "soundbase.h"
@@ -118,4 +119,8 @@ protected:
     QString             sChannelNamesOutput[MAX_NUM_IN_OUT_CHANNELS];
 
     QMutex              Mutex;
+
+  private:
+    OSStatus            CheckError(OSStatus error, const char *operation);
+    OSStatus            CountChannels(AudioDeviceID devID, bool isInput);
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -47,7 +47,7 @@ CClient::CClient ( const quint16  iPortNumber,
     bWindowWasShownConnect           ( false ),
     Channel                          ( false ), /* we need a client channel -> "false" */
     eAudioCompressionType            ( CT_OPUS ),
-    iCeltNumCodedBytes               ( OPUS_NUM_BYTES_MONO_LOW_QUALITY ),
+    iCeltNumCodedBytes               ( OPUS_NUM_BYTES_STEREO_HIGH_QUALITY ),
     eAudioQuality                    ( AQ_LOW ),
     eAudioChannelConf                ( CC_MONO ),
     bIsInitializationPhase           ( true ),

--- a/src/client.h
+++ b/src/client.h
@@ -89,7 +89,7 @@
 
 #define OPUS_NUM_BYTES_STEREO_LOW_QUALITY       47
 #define OPUS_NUM_BYTES_STEREO_NORMAL_QUALITY    71
-#define OPUS_NUM_BYTES_STEREO_HIGH_QUALITY      142
+#define OPUS_NUM_BYTES_STEREO_HIGH_QUALITY      71
 
 
 /* Classes ********************************************************************/

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -536,15 +536,15 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( CHostAddress&                
         switch ( ePingTimeLEDColor )
         {
         case CMultiColorLED::RL_GREEN:
-            pCurListViewItem->setTextColor ( 1, Qt::darkGreen );
+            pCurListViewItem->setForeground ( 1, Qt::darkGreen );
             break;
 
         case CMultiColorLED::RL_YELLOW:
-            pCurListViewItem->setTextColor ( 1, Qt::darkYellow );
+            pCurListViewItem->setForeground( 1, Qt::darkYellow );
             break;
 
         default: // including "CMultiColorLED::RL_RED"
-            pCurListViewItem->setTextColor ( 1, Qt::red );
+            pCurListViewItem->setForeground ( 1, Qt::red );
             break;
         }
 

--- a/src/global.h
+++ b/src/global.h
@@ -111,8 +111,8 @@ LED bar:      lbr
 
 // System block size, this is the block size on which the audio coder works.
 // All other block sizes must be a multiple of this size.
-// Note that the UpdateAutoSetting() function assumes a value of 128.
-#define SYSTEM_FRAME_SIZE_SAMPLES       128
+// Note that the UpdateAutoSetting() function assumes a value of 64.
+#define SYSTEM_FRAME_SIZE_SAMPLES       64
 
 #define SYSTEM_BLOCK_DURATION_MS_FLOAT  \
     ( static_cast<double> ( SYSTEM_FRAME_SIZE_SAMPLES ) / \
@@ -121,9 +121,9 @@ LED bar:      lbr
 // define the allowed audio frame size factors (since the
 // "SYSTEM_FRAME_SIZE_SAMPLES" is quite small, it may be that on some
 // computers a larger value is required)
-#define FRAME_SIZE_FACTOR_PREFERRED     1 // 128 (for frame size 128)
-#define FRAME_SIZE_FACTOR_DEFAULT       2 // 256 (for frame size 128)
-#define FRAME_SIZE_FACTOR_SAFE          4 // 512 (for frame size 128)
+#define FRAME_SIZE_FACTOR_PREFERRED     1 // 64 (for frame size 64)
+#define FRAME_SIZE_FACTOR_DEFAULT       2 // 128 (for frame size 64)
+#define FRAME_SIZE_FACTOR_SAFE          4 // 256 (for frame size 64)
 
 // low complexity CELT encoder (if defined)
 #define USE_LOW_COMPLEXITY_CELT_ENC

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -30,9 +30,9 @@
 CHighPrecisionTimer::CHighPrecisionTimer()
 {
     // add some error checking, the high precision timer implementation only
-    // supports 128 samples frame size at 48 kHz sampling rate
-#if ( SYSTEM_FRAME_SIZE_SAMPLES != 128 )
-# error "Only system frame size of 128 samples is supported by this module"
+    // supports 64 samples frame size at 48 kHz sampling rate
+#if ( SYSTEM_FRAME_SIZE_SAMPLES != 64 )
+# error "Only system frame size of 64 samples is supported by this module"
 #endif
 #if ( SYSTEM_SAMPLE_RATE_HZ != 48000 )
 # error "Only a system sample rate of 48 kHz is supported by this module"
@@ -65,7 +65,7 @@ void CHighPrecisionTimer::Start()
     iIntervalCounter = 0;
 
     // start internal timer with 2 ms resolution
-    Timer.start ( 2 );
+    Timer.start ( 1);
 }
 
 void CHighPrecisionTimer::Stop()

--- a/src/serverlogging.h
+++ b/src/serverlogging.h
@@ -61,7 +61,4 @@ protected:
     bool              bDoLogging;
     QFile             File;
 
-private:
-    int               iHistNumItems;
-    int               iHistMaxDays;
 };


### PR DESCRIPTION
The CoreAudio layer to figure out what inputs are available only worked on multiple channels per stream devices.

This PR adds support for the case where _input_ devices have multiple discrete buffers and have need to pull the data out of those buffers properly.

