### PR TITLE
Use server internal address in server list

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -231,7 +231,7 @@ LED bar:      lbr
 #define MAX_LEN_CHAT_TEXT               1600
 #define MAX_LEN_CHAT_TEXT_PLUS_HTML     1800
 #define MAX_LEN_SERVER_NAME             20
-#define MAX_LEN_SERVER_TOPIC            32
+#define MAX_LEN_IP_ADDRESS              15
 #define MAX_LEN_SERVER_CITY             20
 #define MAX_LEN_VERSION_TEXT            20
 

--- a/src/global.h
+++ b/src/global.h
@@ -110,6 +110,12 @@ LED bar:      lbr
 // download URL
 #define LLCON_DOWNLOAD_URL              "http://sourceforge.net/projects/llcon/files"
 
+// determining server internal address uses well-known host and port
+// (Google DNS, or something else reliable)
+#define WELL_KNOWN_HOST                 "8.8.8.8"  // Google
+#define WELL_KNOWN_PORT                  53        // DNS
+#define IP_LOOKUP_TIMEOUT                500       // ms
+
 // defined port number for client and server
 #if ( SYSTEM_FRAME_SIZE_SAMPLES == 64 )
 # define LLCON_DEFAULT_PORT_NUMBER      22064 // different port number for 64 samples frame size version

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -1473,7 +1473,7 @@ bool CProtocol::EvaluateCLRegisterServerMes ( const CHostAddress&     InetAddr,
 
     // port number (2 bytes)
     RecServerInfo.iLocalPortNumber =
-        static_cast<uint16_t> ( GetValFromStream ( vecData, iPos, 2 ) );
+        static_cast<quint16> ( GetValFromStream ( vecData, iPos, 2 ) );
 
     // country (2 bytes)
     RecServerInfo.eCountry =
@@ -1633,11 +1633,11 @@ bool CProtocol::EvaluateCLServerListMes ( const CHostAddress&     InetAddr,
 
         // IP address (4 bytes)
         const quint32 iIpAddr =
-            static_cast<uint32_t> ( GetValFromStream ( vecData, iPos, 4 ) );
+            static_cast<quint32> ( GetValFromStream ( vecData, iPos, 4 ) );
 
         // port number (2 bytes)
         const quint16 iPort =
-            static_cast<uint16_t> ( GetValFromStream ( vecData, iPos, 2 ) );
+            static_cast<quint16> ( GetValFromStream ( vecData, iPos, 2 ) );
 
         // country (2 bytes)
         const QLocale::Country eCountry =

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -112,6 +112,7 @@ public:
                                          const int           iNumClients );
     void CreateCLServerFullMes         ( const CHostAddress& InetAddr );
     void CreateCLRegisterServerMes     ( const CHostAddress&    InetAddr,
+                                         const CHostAddress&    LInetAddr,
                                          const CServerCoreInfo& ServerInfo );
     void CreateCLUnregisterServerMes   ( const CHostAddress& InetAddr );
     void CreateCLServerListMes         ( const CHostAddress&        InetAddr,
@@ -287,6 +288,7 @@ signals:
                                         int                    iMs,
                                         int                    iNumClients );
     void CLRegisterServerReceived     ( CHostAddress           InetAddr,
+                                        CHostAddress           LInetAddr,
                                         CServerCoreInfo        ServerInfo );
     void CLUnregisterServerReceived   ( CHostAddress           InetAddr );
     void CLServerListReceived         ( CHostAddress           InetAddr,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -427,8 +427,8 @@ CServer::CServer ( const int          iNewMaxNumChan,
         this, SLOT ( OnCLPingWithNumClientsReceived ( CHostAddress, int, int ) ) );
 
     QObject::connect ( &ConnLessProtocol,
-        SIGNAL ( CLRegisterServerReceived ( CHostAddress, CServerCoreInfo ) ),
-        this, SLOT ( OnCLRegisterServerReceived ( CHostAddress, CServerCoreInfo ) ) );
+        SIGNAL ( CLRegisterServerReceived ( CHostAddress, CHostAddress, CServerCoreInfo ) ),
+        this, SLOT ( OnCLRegisterServerReceived ( CHostAddress, CHostAddress, CServerCoreInfo ) ) );
 
     QObject::connect ( &ConnLessProtocol,
         SIGNAL ( CLUnregisterServerReceived ( CHostAddress ) ),

--- a/src/server.h
+++ b/src/server.h
@@ -367,9 +367,10 @@ public slots:
         { ConnLessProtocol.CreateCLConnClientsListMes ( InetAddr, CreateChannelList() ); }
 
     void OnCLRegisterServerReceived ( CHostAddress    InetAddr,
+                                      CHostAddress    LInetAddr,
                                       CServerCoreInfo ServerInfo )
     {
-        ServerListManager.CentralServerRegisterServer ( InetAddr, ServerInfo );
+        ServerListManager.CentralServerRegisterServer ( InetAddr, LInetAddr, ServerInfo );
     }
 
     void OnCLUnregisterServerReceived ( CHostAddress InetAddr )

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -329,16 +329,12 @@ void CServerListManager::CentralServerRegisterServer ( const CHostAddress&    In
             const int ciInvalidIdx = -1;
 
             // Check if server is already registered.
-            // Use external address and local port to identify a server
-            // (there could be more than one server on the external address
-            // but they would have to use separate ports).
             // The very first list entry must not be checked since
             // this is per definition the central server (i.e., this server)
             int iSelIdx = ciInvalidIdx; // initialize with an illegal value
             for ( int iIdx = 1; iIdx < iCurServerListSize; iIdx++ )
             {
-                if ( ServerList[iIdx].HostAddr == InetAddr
-                     && ServerList[iIdx].iLocalPortNumber == ServerInfo.iLocalPortNumber )
+                if ( ServerList[iIdx].HostAddr == InetAddr )
                 {
                     // store entry index
                     iSelIdx = iIdx;

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -75,8 +75,8 @@ class CServerListEntry : public CServerInfo
 public:
     CServerListEntry() :
         CServerInfo ( CHostAddress(),
+                      CHostAddress(),
                       0,
-                      "",
                       "",
                       QLocale::AnyCountry,
                       "",
@@ -84,28 +84,29 @@ public:
                       false ) { UpdateRegistration(); }
 
     CServerListEntry ( const CHostAddress&     NHAddr,
+                       const CHostAddress&     NLHAddr,
                        const quint16           NLocPort,
                        const QString&          NsName,
-                       const QString&          NsTopic,
                        const QLocale::Country& NeCountry,
                        const QString&          NsCity,
                        const int               NiMaxNumClients,
                        const bool              NbPermOnline)
         : CServerInfo ( NHAddr,
+                        NLHAddr,
                         NLocPort,
                         NsName,
-                        NsTopic,
                         NeCountry,
                         NsCity,
                         NiMaxNumClients,
                         NbPermOnline ) { UpdateRegistration(); }
 
     CServerListEntry ( const CHostAddress&    NHAddr,
+                       const CHostAddress&    NLHAddr,
                        const CServerCoreInfo& NewCoreServerInfo )
         : CServerInfo ( NHAddr,
+                        NLHAddr,
                         NewCoreServerInfo.iLocalPortNumber,
                         NewCoreServerInfo.strName,
-                        NewCoreServerInfo.strTopic,
                         NewCoreServerInfo.eCountry,
                         NewCoreServerInfo.strCity,
                         NewCoreServerInfo.iMaxNumClients,
@@ -150,6 +151,7 @@ public:
     bool GetIsCentralServer() const { return bIsCentralServer; }
 
     void CentralServerRegisterServer ( const CHostAddress&    InetAddr,
+                                       const CHostAddress&    LInetAddr,
                                        const CServerCoreInfo& ServerInfo );
 
     void CentralServerUnregisterServer ( const CHostAddress& InetAddr );
@@ -197,6 +199,7 @@ protected:
     bool                    bCentServPingServerInList;
 
     CHostAddress            SlaveCurCentServerHostAddress;
+    CHostAddress            SlaveCurLocalHostAddress;
 
     CProtocol*              pConnLessProtocol;
 

--- a/src/testbench.h
+++ b/src/testbench.h
@@ -88,6 +88,15 @@ protected:
         return strReturn;
     }
 
+    QHostAddress GenRandomIPv4Address() const
+    {
+        uint32_t a = static_cast<uint32_t> ( 192 );
+        uint32_t b = static_cast<uint32_t> ( 168 );
+        uint32_t c = static_cast<uint32_t> ( GenRandomIntInRange ( 1, 253 ) );
+        uint32_t d = static_cast<uint32_t> ( GenRandomIntInRange ( 1, 253 ) );
+        return QHostAddress( a << 24 | b << 16 | c << 8 | d );
+    }
+
     QString    sAddress;
     quint16    iPort;        
     QTimer     Timer;
@@ -102,6 +111,7 @@ public slots:
         CServerCoreInfo        ServerInfo;
         CVector<CServerInfo>   vecServerInfo ( 1 );
         CHostAddress           CurHostAddress ( QHostAddress ( sAddress ), iPort );
+        CHostAddress           CurLocalAddress ( GenRandomIPv4Address(), iPort );
         CChannelCoreInfo       ChannelCoreInfo;
         ELicenceType           eLicenceType;
 
@@ -123,7 +133,7 @@ public slots:
 
         case 4: // PROTMESSID_CONN_CLIENTS_LIST
             vecChanInfo[0].iChanID = GenRandomIntInRange ( -2, 20 );
-            vecChanInfo[0].iIpAddr = GenRandomIntInRange ( 0, 100000 );
+            vecChanInfo[0].iIpAddr = GenRandomIPv4Address().toIPv4Address();
             vecChanInfo[0].strName = GenRandomString();
 
             Protocol.CreateConClientListMes ( vecChanInfo );
@@ -206,9 +216,9 @@ public slots:
             ServerInfo.iMaxNumClients   = GenRandomIntInRange ( -2, 10000 );
             ServerInfo.strCity          = GenRandomString();
             ServerInfo.strName          = GenRandomString();
-            ServerInfo.strTopic         = GenRandomString();
 
             Protocol.CreateCLRegisterServerMes ( CurHostAddress,
+                                                 CurLocalAddress,
                                                  ServerInfo );
             break;
 
@@ -224,11 +234,11 @@ public slots:
                 static_cast<QLocale::Country> ( GenRandomIntInRange ( 0, 100 ) );
 
             vecServerInfo[0].HostAddr         = CurHostAddress;
+            vecServerInfo[0].LHostAddr        = CurLocalAddress;
             vecServerInfo[0].iLocalPortNumber = GenRandomIntInRange ( -2, 10000 );
             vecServerInfo[0].iMaxNumClients   = GenRandomIntInRange ( -2, 10000 );
             vecServerInfo[0].strCity          = GenRandomString();
             vecServerInfo[0].strName          = GenRandomString();
-            vecServerInfo[0].strTopic         = GenRandomString();
 
             Protocol.CreateCLServerListMes ( CurHostAddress,
                                              vecServerInfo );

--- a/src/testbench.h
+++ b/src/testbench.h
@@ -90,10 +90,10 @@ protected:
 
     QHostAddress GenRandomIPv4Address() const
     {
-        uint32_t a = static_cast<uint32_t> ( 192 );
-        uint32_t b = static_cast<uint32_t> ( 168 );
-        uint32_t c = static_cast<uint32_t> ( GenRandomIntInRange ( 1, 253 ) );
-        uint32_t d = static_cast<uint32_t> ( GenRandomIntInRange ( 1, 253 ) );
+        quint32 a = static_cast<quint32> ( 192 );
+        quint32 b = static_cast<quint32> ( 168 );
+        quint32 c = static_cast<quint32> ( GenRandomIntInRange ( 1, 253 ) );
+        quint32 d = static_cast<quint32> ( GenRandomIntInRange ( 1, 253 ) );
         return QHostAddress( a << 24 | b << 16 | c << 8 | d );
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -893,8 +893,8 @@ bool NetworkUtil::ParseNetworkAddress ( QString       strAddress,
 CHostAddress NetworkUtil::GetLocalAddress()
 {
     QTcpSocket socket;
-    socket.connectToHost("8.8.8.8", 53); // google DNS, or something else reliable
-    if (socket.waitForConnected()) {
+    socket.connectToHost( WELL_KNOWN_HOST, WELL_KNOWN_PORT );
+    if (socket.waitForConnected( IP_LOOKUP_TIMEOUT )) {
         return CHostAddress( socket.localAddress(), 0 );
     } else {
         qWarning()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -890,6 +890,20 @@ bool NetworkUtil::ParseNetworkAddress ( QString       strAddress,
 }
 
 
+CHostAddress NetworkUtil::GetLocalAddress()
+{
+    QTcpSocket socket;
+    socket.connectToHost("8.8.8.8", 53); // google DNS, or something else reliable
+    if (socket.waitForConnected()) {
+        return CHostAddress( socket.localAddress(), 0 );
+    } else {
+        qWarning()
+            << "could not determine local IPv4 address:"
+            << socket.errorString()
+            << "- using localhost";
+        return CHostAddress( QHostAddress::LocalHost, 0 );
+    }
+}
 // Instrument picture data base ------------------------------------------------
 CVector<CInstPictures::CInstPictProps>& CInstPictures::GetTable()
 {

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <QTcpSocket>
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QMenu>
@@ -861,7 +862,6 @@ public:
     CServerCoreInfo() :
         iLocalPortNumber ( 0 ),
         strName          ( "" ),
-        strTopic         ( "" ),
         eCountry         ( QLocale::AnyCountry ),
         strCity          ( "" ),
         iMaxNumClients   ( 0 ),
@@ -870,14 +870,12 @@ public:
     CServerCoreInfo (
         const quint16           NLocPort,
         const QString&          NsName,
-        const QString&          NsTopic,
         const QLocale::Country& NeCountry,
         const QString&          NsCity,
         const int               NiMaxNumClients,
         const bool              NbPermOnline) :
         iLocalPortNumber ( NLocPort ),
         strName          ( NsName ),
-        strTopic         ( NsTopic ),
         eCountry         ( NeCountry ),
         strCity          ( NsCity ),
         iMaxNumClients   ( NiMaxNumClients ),
@@ -888,9 +886,6 @@ public:
 
     // name of the server
     QString          strName;
-
-    // topic of the current jam session or server
-    QString          strTopic;
 
     // country in which the server is located
     QLocale::Country eCountry;
@@ -910,27 +905,33 @@ class CServerInfo : public CServerCoreInfo
 {
 public:
     CServerInfo() :
-        HostAddr ( CHostAddress() ) {}
+        HostAddr  ( CHostAddress() ),
+        LHostAddr ( CHostAddress() )
+    {}
 
     CServerInfo (
         const CHostAddress&     NHAddr,
+        const CHostAddress&     NLAddr,
         const quint16           NLocPort,
         const QString&          NsName,
-        const QString&          NsTopic,
         const QLocale::Country& NeCountry,
         const QString&          NsCity,
         const int               NiMaxNumClients,
         const bool              NbPermOnline) :
             CServerCoreInfo ( NLocPort,
                               NsName,
-                              NsTopic,
                               NeCountry,
                               NsCity,
                               NiMaxNumClients,
-                              NbPermOnline ), HostAddr ( NHAddr ) {}
+                              NbPermOnline ),
+            HostAddr        ( NHAddr ),
+            LHostAddr       ( NLAddr ) {}
 
     // internet address of the server
     CHostAddress HostAddr;
+
+    // server internal address
+    CHostAddress LHostAddr;
 };
 
 
@@ -977,6 +978,8 @@ class NetworkUtil
 public:
     static bool ParseNetworkAddress ( QString       strAddress,
                                       CHostAddress& HostAddress );
+
+    static CHostAddress GetLocalAddress();
 };
 
 


### PR DESCRIPTION
I changed a few casts that were giving warnings about incompatible types, as well (in the areas I was changing anyway).

Also added a random IP generator - I didn't work out how the test bench works but it compiles :).

Tests:

New to New
- local "central" server IP-1, port A
- local "slave" server IP-1, port B, registers with "central"
- local client IP-1, port C, requests server list from "central", sees "central" and "slave"
- local client IP-2, port C, requests server list from "central", sees "central" and "slave"

New to Old
- local client IP-1, port C, requests server list from default, gets normal list

Didn't do (could have done for _one_ slave to a central, I think)
- New server to Old central
- Old server to New central
- Old client to New server