### PR TITLE
Tidy away local port in CServerCoreInfo etc

### DIFF
--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -76,7 +76,6 @@ public:
     CServerListEntry() :
         CServerInfo ( CHostAddress(),
                       CHostAddress(),
-                      0,
                       "",
                       QLocale::AnyCountry,
                       "",
@@ -85,7 +84,6 @@ public:
 
     CServerListEntry ( const CHostAddress&     NHAddr,
                        const CHostAddress&     NLHAddr,
-                       const quint16           NLocPort,
                        const QString&          NsName,
                        const QLocale::Country& NeCountry,
                        const QString&          NsCity,
@@ -93,7 +91,6 @@ public:
                        const bool              NbPermOnline)
         : CServerInfo ( NHAddr,
                         NLHAddr,
-                        NLocPort,
                         NsName,
                         NeCountry,
                         NsCity,
@@ -105,7 +102,6 @@ public:
                        const CServerCoreInfo& NewCoreServerInfo )
         : CServerInfo ( NHAddr,
                         NLHAddr,
-                        NewCoreServerInfo.iLocalPortNumber,
                         NewCoreServerInfo.strName,
                         NewCoreServerInfo.eCountry,
                         NewCoreServerInfo.strCity,

--- a/src/testbench.h
+++ b/src/testbench.h
@@ -45,6 +45,9 @@ public:
         sAddress ( sNewAddress ),
         iPort    ( iNewPort )
     {
+        sLAddress = GenRandomIPv4Address().toString();
+        iLPort = static_cast<quint16> ( GenRandomIntInRange ( -2, 10000 ) );
+
         // bind socket (try 100 port numbers)
         quint16 iPortIncrement = 0;     // start value: port nubmer plus ten
         bool    bSuccess       = false; // initialization for while loop
@@ -98,7 +101,9 @@ protected:
     }
 
     QString    sAddress;
-    quint16    iPort;        
+    quint16    iPort;
+    QString    sLAddress;
+    quint16    iLPort;
     QTimer     Timer;
     CProtocol  Protocol;
     QUdpSocket UdpSocket;
@@ -111,7 +116,7 @@ public slots:
         CServerCoreInfo        ServerInfo;
         CVector<CServerInfo>   vecServerInfo ( 1 );
         CHostAddress           CurHostAddress ( QHostAddress ( sAddress ), iPort );
-        CHostAddress           CurLocalAddress ( GenRandomIPv4Address(), iPort );
+        CHostAddress           CurLocalAddress ( QHostAddress ( sLAddress ), iLPort );
         CChannelCoreInfo       ChannelCoreInfo;
         ELicenceType           eLicenceType;
 
@@ -212,7 +217,6 @@ public slots:
             ServerInfo.eCountry =
                 static_cast<QLocale::Country> ( GenRandomIntInRange ( 0, 100 ) );
 
-            ServerInfo.iLocalPortNumber = GenRandomIntInRange ( -2, 10000 );
             ServerInfo.iMaxNumClients   = GenRandomIntInRange ( -2, 10000 );
             ServerInfo.strCity          = GenRandomString();
             ServerInfo.strName          = GenRandomString();
@@ -235,7 +239,6 @@ public slots:
 
             vecServerInfo[0].HostAddr         = CurHostAddress;
             vecServerInfo[0].LHostAddr        = CurLocalAddress;
-            vecServerInfo[0].iLocalPortNumber = GenRandomIntInRange ( -2, 10000 );
             vecServerInfo[0].iMaxNumClients   = GenRandomIntInRange ( -2, 10000 );
             vecServerInfo[0].strCity          = GenRandomString();
             vecServerInfo[0].strName          = GenRandomString();

--- a/src/util.h
+++ b/src/util.h
@@ -870,7 +870,6 @@ class CServerCoreInfo
 {
 public:
     CServerCoreInfo() :
-        iLocalPortNumber ( 0 ),
         strName          ( "" ),
         eCountry         ( QLocale::AnyCountry ),
         strCity          ( "" ),
@@ -878,21 +877,16 @@ public:
         bPermanentOnline ( false ) {}
 
     CServerCoreInfo (
-        const quint16           NLocPort,
         const QString&          NsName,
         const QLocale::Country& NeCountry,
         const QString&          NsCity,
         const int               NiMaxNumClients,
         const bool              NbPermOnline) :
-        iLocalPortNumber ( NLocPort ),
         strName          ( NsName ),
         eCountry         ( NeCountry ),
         strCity          ( NsCity ),
         iMaxNumClients   ( NiMaxNumClients ),
         bPermanentOnline ( NbPermOnline ) {}
-
-    // local port number of the server
-    quint16          iLocalPortNumber;
 
     // name of the server
     QString          strName;
@@ -922,14 +916,12 @@ public:
     CServerInfo (
         const CHostAddress&     NHAddr,
         const CHostAddress&     NLAddr,
-        const quint16           NLocPort,
         const QString&          NsName,
         const QLocale::Country& NeCountry,
         const QString&          NsCity,
         const int               NiMaxNumClients,
         const bool              NbPermOnline) :
-            CServerCoreInfo ( NLocPort,
-                              NsName,
+            CServerCoreInfo ( NsName,
                               NeCountry,
                               NsCity,
                               NiMaxNumClients,


### PR DESCRIPTION
This clears up "iLocalPort".  Tested locally.  The protocol layer isn't much changed - changed the comment regarding the port to make it clear what it's holding.

Also allowed a full central server to update registered existing servers.