### PR TITLE
Refactor signal to slot connections using recursive templates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,13 +17,13 @@ Linux
 Required packages: 
 
 - Build-Essential
-- Qt4/Qt5 (devel packages, too!)
+- Qt5 (devel packages, too!)
 - Jack (devel packages, too!)
 - qjackctl can be a good help configure jack.
 
 On the most common Linux distributions, the following command should prepare the system for compilation:
 
-sudo apt-get install build-essential libqt4-dev libjack-jackd2-dev
+sudo apt-get install build-essential qt5-default libjack-jackd2-dev
 
 On Fedora use:
 
@@ -43,7 +43,7 @@ To use an external shared OPUS library instead of the built-in use qmake `"CONFI
 
 To use this file configure the software with `qmake "CONFIG+=noupcasename" Jamulus.pro` to make sure the output target name of this software is jamulus instead of Jamulus.
 
-Jamulus is also compatible with Qt5.
+Jamulus requires Qt5.
 
 To configure and run Jamulus as a server, see the [server documentation](https://github.com/corrados/jamulus/wiki/Running-a-Server).
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -560,112 +560,29 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent, Qt::WindowFlags ) :
     setHorizontalScrollBarPolicy ( Qt::ScrollBarAsNeeded );
     setFrameShape ( QFrame::NoFrame );
 
-
     // Connections -------------------------------------------------------------
-    // CODE TAG: MAX_NUM_CHANNELS_TAG
-    // make sure we have MAX_NUM_CHANNELS connections!!!
-    QObject::connect ( vecpChanFader[0],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh0  ( double ) ) );
-    QObject::connect ( vecpChanFader[1],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh1  ( double ) ) );
-    QObject::connect ( vecpChanFader[2],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh2  ( double ) ) );
-    QObject::connect ( vecpChanFader[3],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh3  ( double ) ) );
-    QObject::connect ( vecpChanFader[4],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh4  ( double ) ) );
-    QObject::connect ( vecpChanFader[5],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh5  ( double ) ) );
-    QObject::connect ( vecpChanFader[6],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh6  ( double ) ) );
-    QObject::connect ( vecpChanFader[7],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh7  ( double ) ) );
-    QObject::connect ( vecpChanFader[8],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh8  ( double ) ) );
-    QObject::connect ( vecpChanFader[9],  SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh9  ( double ) ) );
-    QObject::connect ( vecpChanFader[10], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh10 ( double ) ) );
-    QObject::connect ( vecpChanFader[11], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh11 ( double ) ) );
-    QObject::connect ( vecpChanFader[12], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh12 ( double ) ) );
-    QObject::connect ( vecpChanFader[13], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh13 ( double ) ) );
-    QObject::connect ( vecpChanFader[14], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh14 ( double ) ) );
-    QObject::connect ( vecpChanFader[15], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh15 ( double ) ) );
-    QObject::connect ( vecpChanFader[16], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh16 ( double ) ) );
-    QObject::connect ( vecpChanFader[17], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh17 ( double ) ) );
-    QObject::connect ( vecpChanFader[18], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh18 ( double ) ) );
-    QObject::connect ( vecpChanFader[19], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh19 ( double ) ) );
-    QObject::connect ( vecpChanFader[20], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh20 ( double ) ) );
-    QObject::connect ( vecpChanFader[21], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh21 ( double ) ) );
-    QObject::connect ( vecpChanFader[22], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh22 ( double ) ) );
-    QObject::connect ( vecpChanFader[23], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh23 ( double ) ) );
-    QObject::connect ( vecpChanFader[24], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh24 ( double ) ) );
-    QObject::connect ( vecpChanFader[25], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh25 ( double ) ) );
-    QObject::connect ( vecpChanFader[26], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh26 ( double ) ) );
-    QObject::connect ( vecpChanFader[27], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh27 ( double ) ) );
-    QObject::connect ( vecpChanFader[28], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh28 ( double ) ) );
-    QObject::connect ( vecpChanFader[29], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh29 ( double ) ) );
-    QObject::connect ( vecpChanFader[30], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh30 ( double ) ) );
-    QObject::connect ( vecpChanFader[31], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh31 ( double ) ) );
-    QObject::connect ( vecpChanFader[32], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh32 ( double ) ) );
-    QObject::connect ( vecpChanFader[33], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh33 ( double ) ) );
-    QObject::connect ( vecpChanFader[34], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh34 ( double ) ) );
-    QObject::connect ( vecpChanFader[35], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh35 ( double ) ) );
-    QObject::connect ( vecpChanFader[36], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh36 ( double ) ) );
-    QObject::connect ( vecpChanFader[37], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh37 ( double ) ) );
-    QObject::connect ( vecpChanFader[38], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh38 ( double ) ) );
-    QObject::connect ( vecpChanFader[39], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh39 ( double ) ) );
-    QObject::connect ( vecpChanFader[40], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh40 ( double ) ) );
-    QObject::connect ( vecpChanFader[41], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh41 ( double ) ) );
-    QObject::connect ( vecpChanFader[42], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh42 ( double ) ) );
-    QObject::connect ( vecpChanFader[43], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh43 ( double ) ) );
-    QObject::connect ( vecpChanFader[44], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh44 ( double ) ) );
-    QObject::connect ( vecpChanFader[45], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh45 ( double ) ) );
-    QObject::connect ( vecpChanFader[46], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh46 ( double ) ) );
-    QObject::connect ( vecpChanFader[47], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh47 ( double ) ) );
-    QObject::connect ( vecpChanFader[48], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh48 ( double ) ) );
-    QObject::connect ( vecpChanFader[49], SIGNAL ( gainValueChanged ( double ) ), this, SLOT ( OnGainValueChangedCh49 ( double ) ) );
-
-    QObject::connect ( vecpChanFader[0],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[1],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[2],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[3],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[4],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[5],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[6],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[7],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[8],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[9],  SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[10], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[11], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[12], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[13], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[14], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[15], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[16], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[17], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[18], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[19], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[20], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[21], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[22], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[23], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[24], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[25], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[26], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[27], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[28], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[29], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[30], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[31], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[32], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[33], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[34], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[35], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[36], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[37], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[38], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[39], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[40], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[41], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[42], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[43], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[44], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[45], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[46], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[47], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[48], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
-    QObject::connect ( vecpChanFader[49], SIGNAL ( soloStateChanged ( int ) ), this, SLOT ( OnChSoloStateChanged() ) );
+    connectFaderSignalsToMixerBoardSlots<MAX_NUM_CHANNELS>();
 }
+
+template<unsigned int slotId>
+inline void CAudioMixerBoard::connectFaderSignalsToMixerBoardSlots()
+{
+    int iCurChanID = slotId - 1;
+
+    void ( CAudioMixerBoard::* pGainValueChanged )( double ) =
+        &CAudioMixerBoardSlots<slotId>::OnChGainValueChanged;
+
+    QObject::connect ( vecpChanFader[iCurChanID], &CChannelFader::soloStateChanged,
+                       this, &CAudioMixerBoard::UpdateSoloStates );
+
+    QObject::connect ( vecpChanFader[iCurChanID], &CChannelFader::gainValueChanged,
+                       this, pGainValueChanged );
+
+    connectFaderSignalsToMixerBoardSlots<slotId - 1>();
+};
+
+template<>
+inline void CAudioMixerBoard::connectFaderSignalsToMixerBoardSlots<0>() {};
 
 void CAudioMixerBoard::SetServerName ( const QString& strNewServerName )
 {
@@ -875,8 +792,8 @@ void CAudioMixerBoard::UpdateSoloStates()
     }
 }
 
-void CAudioMixerBoard::OnGainValueChanged ( const int    iChannelIdx,
-                                            const double dValue )
+void CAudioMixerBoard::UpdateGainValue ( const int    iChannelIdx,
+                                         const double dValue )
 {
     emit ChangeChanGain ( iChannelIdx, dValue );
 }

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -40,6 +40,22 @@
 
 
 /* Classes ********************************************************************/
+template<unsigned int slotId>
+class CAudioMixerBoardSlots : public CAudioMixerBoardSlots<slotId - 1>
+{
+
+public:
+    void OnChGainValueChanged ( double dValue ) { UpdateGainValue ( slotId - 1, dValue ); }
+
+protected:
+    virtual void UpdateGainValue ( const int    iChannelIdx,
+                                   const double dValue ) = 0;
+};
+
+template<>
+class CAudioMixerBoardSlots<0> {};
+
+
 class CChannelFader : public QObject
 {
     Q_OBJECT
@@ -102,7 +118,10 @@ signals:
 };
 
 
-class CAudioMixerBoard : public QScrollArea
+class CAudioMixerBoard :
+    public QScrollArea,
+    public CAudioMixerBoardSlots<MAX_NUM_CHANNELS>
+
 {
     Q_OBJECT
 
@@ -136,8 +155,8 @@ protected:
     void StoreFaderSettings ( CChannelFader* pChanFader );
     void UpdateSoloStates();
 
-    void OnGainValueChanged ( const int    iChannelIdx,
-                              const double dValue );
+    virtual void UpdateGainValue ( const int    iChannelIdx,
+                                   const double dValue );
 
     CVector<CChannelFader*> vecpChanFader;
     QGroupBox*              pGroupBox;
@@ -146,63 +165,13 @@ protected:
     bool                    bNoFaderVisible;
     QString                 strServerName;
 
-public slots:
-    // CODE TAG: MAX_NUM_CHANNELS_TAG
-    // make sure we have MAX_NUM_CHANNELS connections!!!
-    void OnGainValueChangedCh0  ( double dValue ) { OnGainValueChanged ( 0,  dValue ); }
-    void OnGainValueChangedCh1  ( double dValue ) { OnGainValueChanged ( 1,  dValue ); }
-    void OnGainValueChangedCh2  ( double dValue ) { OnGainValueChanged ( 2,  dValue ); }
-    void OnGainValueChangedCh3  ( double dValue ) { OnGainValueChanged ( 3,  dValue ); }
-    void OnGainValueChangedCh4  ( double dValue ) { OnGainValueChanged ( 4,  dValue ); }
-    void OnGainValueChangedCh5  ( double dValue ) { OnGainValueChanged ( 5,  dValue ); }
-    void OnGainValueChangedCh6  ( double dValue ) { OnGainValueChanged ( 6,  dValue ); }
-    void OnGainValueChangedCh7  ( double dValue ) { OnGainValueChanged ( 7,  dValue ); }
-    void OnGainValueChangedCh8  ( double dValue ) { OnGainValueChanged ( 8,  dValue ); }
-    void OnGainValueChangedCh9  ( double dValue ) { OnGainValueChanged ( 9,  dValue ); }
-    void OnGainValueChangedCh10 ( double dValue ) { OnGainValueChanged ( 10, dValue ); }
-    void OnGainValueChangedCh11 ( double dValue ) { OnGainValueChanged ( 11, dValue ); }
-    void OnGainValueChangedCh12 ( double dValue ) { OnGainValueChanged ( 12, dValue ); }
-    void OnGainValueChangedCh13 ( double dValue ) { OnGainValueChanged ( 13, dValue ); }
-    void OnGainValueChangedCh14 ( double dValue ) { OnGainValueChanged ( 14, dValue ); }
-    void OnGainValueChangedCh15 ( double dValue ) { OnGainValueChanged ( 15, dValue ); }
-    void OnGainValueChangedCh16 ( double dValue ) { OnGainValueChanged ( 16, dValue ); }
-    void OnGainValueChangedCh17 ( double dValue ) { OnGainValueChanged ( 17, dValue ); }
-    void OnGainValueChangedCh18 ( double dValue ) { OnGainValueChanged ( 18, dValue ); }
-    void OnGainValueChangedCh19 ( double dValue ) { OnGainValueChanged ( 19, dValue ); }
-    void OnGainValueChangedCh20 ( double dValue ) { OnGainValueChanged ( 20, dValue ); }
-    void OnGainValueChangedCh21 ( double dValue ) { OnGainValueChanged ( 21, dValue ); }
-    void OnGainValueChangedCh22 ( double dValue ) { OnGainValueChanged ( 22, dValue ); }
-    void OnGainValueChangedCh23 ( double dValue ) { OnGainValueChanged ( 23, dValue ); }
-    void OnGainValueChangedCh24 ( double dValue ) { OnGainValueChanged ( 24, dValue ); }
-    void OnGainValueChangedCh25 ( double dValue ) { OnGainValueChanged ( 25, dValue ); }
-    void OnGainValueChangedCh26 ( double dValue ) { OnGainValueChanged ( 26, dValue ); }
-    void OnGainValueChangedCh27 ( double dValue ) { OnGainValueChanged ( 27, dValue ); }
-    void OnGainValueChangedCh28 ( double dValue ) { OnGainValueChanged ( 28, dValue ); }
-    void OnGainValueChangedCh29 ( double dValue ) { OnGainValueChanged ( 29, dValue ); }
-    void OnGainValueChangedCh30 ( double dValue ) { OnGainValueChanged ( 30, dValue ); }
-    void OnGainValueChangedCh31 ( double dValue ) { OnGainValueChanged ( 31, dValue ); }
-    void OnGainValueChangedCh32 ( double dValue ) { OnGainValueChanged ( 32, dValue ); }
-    void OnGainValueChangedCh33 ( double dValue ) { OnGainValueChanged ( 33, dValue ); }
-    void OnGainValueChangedCh34 ( double dValue ) { OnGainValueChanged ( 34, dValue ); }
-    void OnGainValueChangedCh35 ( double dValue ) { OnGainValueChanged ( 35, dValue ); }
-    void OnGainValueChangedCh36 ( double dValue ) { OnGainValueChanged ( 36, dValue ); }
-    void OnGainValueChangedCh37 ( double dValue ) { OnGainValueChanged ( 37, dValue ); }
-    void OnGainValueChangedCh38 ( double dValue ) { OnGainValueChanged ( 38, dValue ); }
-    void OnGainValueChangedCh39 ( double dValue ) { OnGainValueChanged ( 39, dValue ); }
-    void OnGainValueChangedCh40 ( double dValue ) { OnGainValueChanged ( 40, dValue ); }
-    void OnGainValueChangedCh41 ( double dValue ) { OnGainValueChanged ( 41, dValue ); }
-    void OnGainValueChangedCh42 ( double dValue ) { OnGainValueChanged ( 42, dValue ); }
-    void OnGainValueChangedCh43 ( double dValue ) { OnGainValueChanged ( 43, dValue ); }
-    void OnGainValueChangedCh44 ( double dValue ) { OnGainValueChanged ( 44, dValue ); }
-    void OnGainValueChangedCh45 ( double dValue ) { OnGainValueChanged ( 45, dValue ); }
-    void OnGainValueChangedCh46 ( double dValue ) { OnGainValueChanged ( 46, dValue ); }
-    void OnGainValueChangedCh47 ( double dValue ) { OnGainValueChanged ( 47, dValue ); }
-    void OnGainValueChangedCh48 ( double dValue ) { OnGainValueChanged ( 48, dValue ); }
-    void OnGainValueChangedCh49 ( double dValue ) { OnGainValueChanged ( 49, dValue ); }
-
-    void OnChSoloStateChanged() { UpdateSoloStates(); }
+private:
+    template<unsigned int slotId>
+    inline void connectFaderSignalsToMixerBoardSlots();
 
 signals:
     void ChangeChanGain ( int iId, double dGain );
     void NumClientsChanged ( int iNewNumClients );
 };
+
+

--- a/src/global.h
+++ b/src/global.h
@@ -175,9 +175,7 @@ LED bar:      lbr
 #define LOW_BOUND_SIG_METER              ( -50.0 ) // dB
 #define UPPER_BOUND_SIG_METER            ( 0.0 )   // dB
 
-// Maximum number of connected clients at the server. If you want to change this
-// paramter you have to modify the code on some places, too! The code tag
-// "MAX_NUM_CHANNELS_TAG" shows these places (just search for the tag in the entire code)
+// Maximum number of connected clients at the server.
 #define MAX_NUM_CHANNELS                 50 // max number channels for server
 
 // actual number of used channels in the server

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -454,275 +454,57 @@ CServer::CServer ( const int          iNewMaxNumChan,
         SIGNAL ( CLReqConnClientsList ( CHostAddress ) ),
         this, SLOT ( OnCLReqConnClientsList ( CHostAddress ) ) );
 
-    // CODE TAG: MAX_NUM_CHANNELS_TAG
-    // make sure we have MAX_NUM_CHANNELS connections!!!
-    // send message
-    QObject::connect ( &vecChannels[0],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh0  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[1],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh1  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[2],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh2  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[3],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh3  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[4],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh4  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[5],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh5  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[6],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh6  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[7],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh7  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[8],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh8  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[9],  SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh9  ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[10], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh10 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[11], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh11 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[12], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh12 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[13], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh13 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[14], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh14 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[15], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh15 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[16], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh16 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[17], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh17 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[18], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh18 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[19], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh19 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[20], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh20 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[21], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh21 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[22], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh22 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[23], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh23 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[24], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh24 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[25], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh25 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[26], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh26 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[27], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh27 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[28], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh28 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[29], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh29 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[30], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh30 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[31], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh31 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[32], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh32 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[33], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh33 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[34], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh34 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[35], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh35 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[36], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh36 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[37], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh37 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[38], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh38 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[39], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh39 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[40], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh40 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[41], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh41 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[42], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh42 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[43], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh43 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[44], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh44 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[45], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh45 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[46], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh46 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[47], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh47 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[48], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh48 ( CVector<uint8_t> ) ) );
-    QObject::connect ( &vecChannels[49], SIGNAL ( MessReadyForSending ( CVector<uint8_t> ) ), this, SLOT ( OnSendProtMessCh49 ( CVector<uint8_t> ) ) );
-
-    // request connected clients list
-    QObject::connect ( &vecChannels[0],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh0() ) );
-    QObject::connect ( &vecChannels[1],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh1() ) );
-    QObject::connect ( &vecChannels[2],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh2() ) );
-    QObject::connect ( &vecChannels[3],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh3() ) );
-    QObject::connect ( &vecChannels[4],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh4() ) );
-    QObject::connect ( &vecChannels[5],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh5() ) );
-    QObject::connect ( &vecChannels[6],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh6() ) );
-    QObject::connect ( &vecChannels[7],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh7() ) );
-    QObject::connect ( &vecChannels[8],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh8() ) );
-    QObject::connect ( &vecChannels[9],  SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh9() ) );
-    QObject::connect ( &vecChannels[10], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh10() ) );
-    QObject::connect ( &vecChannels[11], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh11() ) );
-    QObject::connect ( &vecChannels[12], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh12() ) );
-    QObject::connect ( &vecChannels[13], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh13() ) );
-    QObject::connect ( &vecChannels[14], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh14() ) );
-    QObject::connect ( &vecChannels[15], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh15() ) );
-    QObject::connect ( &vecChannels[16], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh16() ) );
-    QObject::connect ( &vecChannels[17], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh17() ) );
-    QObject::connect ( &vecChannels[18], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh18() ) );
-    QObject::connect ( &vecChannels[19], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh19() ) );
-    QObject::connect ( &vecChannels[20], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh20() ) );
-    QObject::connect ( &vecChannels[21], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh21() ) );
-    QObject::connect ( &vecChannels[22], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh22() ) );
-    QObject::connect ( &vecChannels[23], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh23() ) );
-    QObject::connect ( &vecChannels[24], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh24() ) );
-    QObject::connect ( &vecChannels[25], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh25() ) );
-    QObject::connect ( &vecChannels[26], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh26() ) );
-    QObject::connect ( &vecChannels[27], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh27() ) );
-    QObject::connect ( &vecChannels[28], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh28() ) );
-    QObject::connect ( &vecChannels[29], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh29() ) );
-    QObject::connect ( &vecChannels[30], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh30() ) );
-    QObject::connect ( &vecChannels[31], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh31() ) );
-    QObject::connect ( &vecChannels[32], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh32() ) );
-    QObject::connect ( &vecChannels[33], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh33() ) );
-    QObject::connect ( &vecChannels[34], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh34() ) );
-    QObject::connect ( &vecChannels[35], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh35() ) );
-    QObject::connect ( &vecChannels[36], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh36() ) );
-    QObject::connect ( &vecChannels[37], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh37() ) );
-    QObject::connect ( &vecChannels[38], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh38() ) );
-    QObject::connect ( &vecChannels[39], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh39() ) );
-    QObject::connect ( &vecChannels[40], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh40() ) );
-    QObject::connect ( &vecChannels[41], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh41() ) );
-    QObject::connect ( &vecChannels[42], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh42() ) );
-    QObject::connect ( &vecChannels[43], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh43() ) );
-    QObject::connect ( &vecChannels[44], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh44() ) );
-    QObject::connect ( &vecChannels[45], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh45() ) );
-    QObject::connect ( &vecChannels[46], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh46() ) );
-    QObject::connect ( &vecChannels[47], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh47() ) );
-    QObject::connect ( &vecChannels[48], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh48() ) );
-    QObject::connect ( &vecChannels[49], SIGNAL ( ReqConnClientsList() ), this, SLOT ( OnReqConnClientsListCh49() ) );
-
-    // channel info has changed
-    QObject::connect ( &vecChannels[0],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh0() ) );
-    QObject::connect ( &vecChannels[1],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh1() ) );
-    QObject::connect ( &vecChannels[2],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh2() ) );
-    QObject::connect ( &vecChannels[3],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh3() ) );
-    QObject::connect ( &vecChannels[4],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh4() ) );
-    QObject::connect ( &vecChannels[5],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh5() ) );
-    QObject::connect ( &vecChannels[6],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh6() ) );
-    QObject::connect ( &vecChannels[7],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh7() ) );
-    QObject::connect ( &vecChannels[8],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh8() ) );
-    QObject::connect ( &vecChannels[9],  SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh9() ) );
-    QObject::connect ( &vecChannels[10], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh10() ) );
-    QObject::connect ( &vecChannels[11], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh11() ) );
-    QObject::connect ( &vecChannels[12], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh12() ) );
-    QObject::connect ( &vecChannels[13], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh13() ) );
-    QObject::connect ( &vecChannels[14], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh14() ) );
-    QObject::connect ( &vecChannels[15], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh15() ) );
-    QObject::connect ( &vecChannels[16], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh16() ) );
-    QObject::connect ( &vecChannels[17], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh17() ) );
-    QObject::connect ( &vecChannels[18], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh18() ) );
-    QObject::connect ( &vecChannels[19], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh19() ) );
-    QObject::connect ( &vecChannels[20], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh20() ) );
-    QObject::connect ( &vecChannels[21], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh21() ) );
-    QObject::connect ( &vecChannels[22], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh22() ) );
-    QObject::connect ( &vecChannels[23], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh23() ) );
-    QObject::connect ( &vecChannels[24], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh24() ) );
-    QObject::connect ( &vecChannels[25], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh25() ) );
-    QObject::connect ( &vecChannels[26], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh26() ) );
-    QObject::connect ( &vecChannels[27], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh27() ) );
-    QObject::connect ( &vecChannels[28], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh28() ) );
-    QObject::connect ( &vecChannels[29], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh29() ) );
-    QObject::connect ( &vecChannels[30], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh30() ) );
-    QObject::connect ( &vecChannels[31], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh31() ) );
-    QObject::connect ( &vecChannels[32], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh32() ) );
-    QObject::connect ( &vecChannels[33], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh33() ) );
-    QObject::connect ( &vecChannels[34], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh34() ) );
-    QObject::connect ( &vecChannels[35], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh35() ) );
-    QObject::connect ( &vecChannels[36], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh36() ) );
-    QObject::connect ( &vecChannels[37], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh37() ) );
-    QObject::connect ( &vecChannels[38], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh38() ) );
-    QObject::connect ( &vecChannels[39], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh39() ) );
-    QObject::connect ( &vecChannels[40], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh40() ) );
-    QObject::connect ( &vecChannels[41], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh41() ) );
-    QObject::connect ( &vecChannels[42], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh42() ) );
-    QObject::connect ( &vecChannels[43], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh43() ) );
-    QObject::connect ( &vecChannels[44], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh44() ) );
-    QObject::connect ( &vecChannels[45], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh45() ) );
-    QObject::connect ( &vecChannels[46], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh46() ) );
-    QObject::connect ( &vecChannels[47], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh47() ) );
-    QObject::connect ( &vecChannels[48], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh48() ) );
-    QObject::connect ( &vecChannels[49], SIGNAL ( ChanInfoHasChanged() ), this, SLOT ( OnChanInfoHasChangedCh49() ) );
-
-    // chat text received
-    QObject::connect ( &vecChannels[0],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh0  ( QString ) ) );
-    QObject::connect ( &vecChannels[1],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh1  ( QString ) ) );
-    QObject::connect ( &vecChannels[2],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh2  ( QString ) ) );
-    QObject::connect ( &vecChannels[3],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh3  ( QString ) ) );
-    QObject::connect ( &vecChannels[4],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh4  ( QString ) ) );
-    QObject::connect ( &vecChannels[5],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh5  ( QString ) ) );
-    QObject::connect ( &vecChannels[6],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh6  ( QString ) ) );
-    QObject::connect ( &vecChannels[7],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh7  ( QString ) ) );
-    QObject::connect ( &vecChannels[8],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh8  ( QString ) ) );
-    QObject::connect ( &vecChannels[9],  SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh9  ( QString ) ) );
-    QObject::connect ( &vecChannels[10], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh10 ( QString ) ) );
-    QObject::connect ( &vecChannels[11], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh11 ( QString ) ) );
-    QObject::connect ( &vecChannels[12], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh12 ( QString ) ) );
-    QObject::connect ( &vecChannels[13], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh13 ( QString ) ) );
-    QObject::connect ( &vecChannels[14], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh14 ( QString ) ) );
-    QObject::connect ( &vecChannels[15], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh15 ( QString ) ) );
-    QObject::connect ( &vecChannels[16], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh16 ( QString ) ) );
-    QObject::connect ( &vecChannels[17], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh17 ( QString ) ) );
-    QObject::connect ( &vecChannels[18], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh18 ( QString ) ) );
-    QObject::connect ( &vecChannels[19], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh19 ( QString ) ) );
-    QObject::connect ( &vecChannels[20], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh20 ( QString ) ) );
-    QObject::connect ( &vecChannels[21], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh21 ( QString ) ) );
-    QObject::connect ( &vecChannels[22], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh22 ( QString ) ) );
-    QObject::connect ( &vecChannels[23], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh23 ( QString ) ) );
-    QObject::connect ( &vecChannels[24], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh24 ( QString ) ) );
-    QObject::connect ( &vecChannels[25], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh25 ( QString ) ) );
-    QObject::connect ( &vecChannels[26], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh26 ( QString ) ) );
-    QObject::connect ( &vecChannels[27], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh27 ( QString ) ) );
-    QObject::connect ( &vecChannels[28], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh28 ( QString ) ) );
-    QObject::connect ( &vecChannels[29], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh29 ( QString ) ) );
-    QObject::connect ( &vecChannels[30], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh30 ( QString ) ) );
-    QObject::connect ( &vecChannels[31], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh31 ( QString ) ) );
-    QObject::connect ( &vecChannels[32], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh32 ( QString ) ) );
-    QObject::connect ( &vecChannels[33], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh33 ( QString ) ) );
-    QObject::connect ( &vecChannels[34], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh34 ( QString ) ) );
-    QObject::connect ( &vecChannels[35], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh35 ( QString ) ) );
-    QObject::connect ( &vecChannels[36], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh36 ( QString ) ) );
-    QObject::connect ( &vecChannels[37], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh37 ( QString ) ) );
-    QObject::connect ( &vecChannels[38], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh38 ( QString ) ) );
-    QObject::connect ( &vecChannels[39], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh39 ( QString ) ) );
-    QObject::connect ( &vecChannels[40], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh40 ( QString ) ) );
-    QObject::connect ( &vecChannels[41], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh41 ( QString ) ) );
-    QObject::connect ( &vecChannels[42], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh42 ( QString ) ) );
-    QObject::connect ( &vecChannels[43], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh43 ( QString ) ) );
-    QObject::connect ( &vecChannels[44], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh44 ( QString ) ) );
-    QObject::connect ( &vecChannels[45], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh45 ( QString ) ) );
-    QObject::connect ( &vecChannels[46], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh46 ( QString ) ) );
-    QObject::connect ( &vecChannels[47], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh47 ( QString ) ) );
-    QObject::connect ( &vecChannels[48], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh48 ( QString ) ) );
-    QObject::connect ( &vecChannels[49], SIGNAL ( ChatTextReceived ( QString ) ), this, SLOT ( OnChatTextReceivedCh49 ( QString ) ) );
-
-    // auto socket buffer size change
-    QObject::connect ( &vecChannels[0],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh0  ( int ) ) );
-    QObject::connect ( &vecChannels[1],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh1  ( int ) ) );
-    QObject::connect ( &vecChannels[2],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh2  ( int ) ) );
-    QObject::connect ( &vecChannels[3],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh3  ( int ) ) );
-    QObject::connect ( &vecChannels[4],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh4  ( int ) ) );
-    QObject::connect ( &vecChannels[5],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh5  ( int ) ) );
-    QObject::connect ( &vecChannels[6],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh6  ( int ) ) );
-    QObject::connect ( &vecChannels[7],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh7  ( int ) ) );
-    QObject::connect ( &vecChannels[8],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh8  ( int ) ) );
-    QObject::connect ( &vecChannels[9],  SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh9  ( int ) ) );
-    QObject::connect ( &vecChannels[10], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh10 ( int ) ) );
-    QObject::connect ( &vecChannels[11], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh11 ( int ) ) );
-    QObject::connect ( &vecChannels[12], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh12 ( int ) ) );
-    QObject::connect ( &vecChannels[13], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh13 ( int ) ) );
-    QObject::connect ( &vecChannels[14], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh14 ( int ) ) );
-    QObject::connect ( &vecChannels[15], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh15 ( int ) ) );
-    QObject::connect ( &vecChannels[16], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh16 ( int ) ) );
-    QObject::connect ( &vecChannels[17], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh17 ( int ) ) );
-    QObject::connect ( &vecChannels[18], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh18 ( int ) ) );
-    QObject::connect ( &vecChannels[19], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh19 ( int ) ) );
-    QObject::connect ( &vecChannels[20], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh20 ( int ) ) );
-    QObject::connect ( &vecChannels[21], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh21 ( int ) ) );
-    QObject::connect ( &vecChannels[22], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh22 ( int ) ) );
-    QObject::connect ( &vecChannels[23], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh23 ( int ) ) );
-    QObject::connect ( &vecChannels[24], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh24 ( int ) ) );
-    QObject::connect ( &vecChannels[25], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh25 ( int ) ) );
-    QObject::connect ( &vecChannels[26], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh26 ( int ) ) );
-    QObject::connect ( &vecChannels[27], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh27 ( int ) ) );
-    QObject::connect ( &vecChannels[28], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh28 ( int ) ) );
-    QObject::connect ( &vecChannels[29], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh29 ( int ) ) );
-    QObject::connect ( &vecChannels[30], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh30 ( int ) ) );
-    QObject::connect ( &vecChannels[31], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh31 ( int ) ) );
-    QObject::connect ( &vecChannels[32], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh32 ( int ) ) );
-    QObject::connect ( &vecChannels[33], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh33 ( int ) ) );
-    QObject::connect ( &vecChannels[34], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh34 ( int ) ) );
-    QObject::connect ( &vecChannels[35], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh35 ( int ) ) );
-    QObject::connect ( &vecChannels[36], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh36 ( int ) ) );
-    QObject::connect ( &vecChannels[37], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh37 ( int ) ) );
-    QObject::connect ( &vecChannels[38], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh38 ( int ) ) );
-    QObject::connect ( &vecChannels[39], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh39 ( int ) ) );
-    QObject::connect ( &vecChannels[40], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh40 ( int ) ) );
-    QObject::connect ( &vecChannels[41], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh41 ( int ) ) );
-    QObject::connect ( &vecChannels[42], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh42 ( int ) ) );
-    QObject::connect ( &vecChannels[43], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh43 ( int ) ) );
-    QObject::connect ( &vecChannels[44], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh44 ( int ) ) );
-    QObject::connect ( &vecChannels[45], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh45 ( int ) ) );
-    QObject::connect ( &vecChannels[46], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh46 ( int ) ) );
-    QObject::connect ( &vecChannels[47], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh47 ( int ) ) );
-    QObject::connect ( &vecChannels[48], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh48 ( int ) ) );
-    QObject::connect ( &vecChannels[49], SIGNAL ( ServerAutoSockBufSizeChange ( int ) ), this, SLOT ( OnServerAutoSockBufSizeChangeCh49 ( int ) ) );
-
+    connectChannelSignalsToServerSlots<MAX_NUM_CHANNELS>();
 
     // start the socket (it is important to start the socket after all
     // initializations and connections)
     Socket.Start();
 }
 
-void CServer::OnSendProtMessage ( int iChID, CVector<uint8_t> vecMessage )
+template<unsigned int slotId>
+inline void CServer::connectChannelSignalsToServerSlots()
+{
+    int iCurChanID = slotId - 1;
+
+    void ( CServer::* pOnSendProtMessCh )( CVector<uint8_t> ) =
+        &CServerSlots<slotId>::OnSendProtMessCh;
+
+    void ( CServer::* pOnReqConnClientsListCh )() =
+        &CServerSlots<slotId>::OnReqConnClientsListCh;
+
+    void ( CServer::* pOnChatTextReceivedCh )( QString ) =
+        &CServerSlots<slotId>::OnChatTextReceivedCh;
+
+    void ( CServer::* pOnServerAutoSockBufSizeChangeCh )( int ) =
+        &CServerSlots<slotId>::OnServerAutoSockBufSizeChangeCh;
+
+    // send message
+    QObject::connect ( &vecChannels[iCurChanID], &CChannel::MessReadyForSending,
+                       this, pOnSendProtMessCh );
+
+    // request connected clients list
+    QObject::connect ( &vecChannels[iCurChanID], &CChannel::ReqConnClientsList,
+                       this, pOnReqConnClientsListCh );
+
+    // channel info has changed
+    QObject::connect ( &vecChannels[iCurChanID], &CChannel::ChanInfoHasChanged,
+            this, &CServer::CreateAndSendChanListForAllConChannels );
+
+    // chat text received
+    QObject::connect ( &vecChannels[iCurChanID], &CChannel::ChatTextReceived,
+            this, pOnChatTextReceivedCh );
+
+    // auto socket buffer size change
+    QObject::connect ( &vecChannels[iCurChanID], &CChannel::ServerAutoSockBufSizeChange,
+            this, pOnServerAutoSockBufSizeChangeCh );
+
+    connectChannelSignalsToServerSlots<slotId - 1>();
+};
+
+template<>
+inline void CServer::connectChannelSignalsToServerSlots<0>() {};
+
+void CServer::SendProtMessage ( int iChID, CVector<uint8_t> vecMessage )
 {
     // the protocol queries me to call the function to send the message
     // send it through the network
@@ -775,10 +557,10 @@ void CServer::OnNewConnection ( int          iChID,
     vecChannels[iChID].ResetTimeOutCounter();
     vecChannels[iChID].CreateReqChanInfoMes();
 
-// COMPATIBILITY ISSUE
-// since old versions of the software did not implement the channel name
-// request message, we have to explicitely send the channel list here
-CreateAndSendChanListForAllConChannels();
+    // COMPATIBILITY ISSUE
+    // since old versions of the software did not implement the channel name
+    // request message, we have to explicitely send the channel list here
+    CreateAndSendChanListForAllConChannels();
 
     // send welcome message (if enabled)
     if ( !strWelcomeMessage.isEmpty() )
@@ -1424,6 +1206,12 @@ void CServer::CreateAndSendChatTextForAllConChannels ( const int      iCurChanID
             vecChannels[i].CreateChatTextMes ( strActualMessageText );
         }
     }
+}
+
+void CServer::CreateAndSendJitBufMessage ( const int iCurChanID,
+                                           const int iNNumFra )
+{
+    vecChannels[iCurChanID].CreateJitBufMes ( iNNumFra );
 }
 
 int CServer::GetFreeChan()

--- a/src/server.h
+++ b/src/server.h
@@ -115,8 +115,43 @@ signals:
 };
 #endif
 
+template<unsigned int slotId>
+class CServerSlots : public CServerSlots<slotId - 1>
+{
 
-class CServer : public QObject
+public:
+    void OnSendProtMessCh( CVector<uint8_t> mess ) { SendProtMessage ( slotId - 1,  mess ); }
+    void OnReqConnClientsListCh()  { CreateAndSendChanListForThisChan ( slotId - 1 ); }
+
+    void OnChatTextReceivedCh( QString strChatText )
+    {
+        CreateAndSendChatTextForAllConChannels ( slotId - 1, strChatText );
+    }
+
+    void OnServerAutoSockBufSizeChangeCh( int iNNumFra )
+    {
+        CreateAndSendJitBufMessage( slotId - 1, iNNumFra );
+    }
+
+protected:
+    virtual void SendProtMessage ( int              iChID,
+                                   CVector<uint8_t> vecMessage ) = 0;
+
+    virtual void CreateAndSendChanListForThisChan ( const int iCurChanID ) = 0;
+
+    virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
+                                                          const QString& strChatText ) = 0;
+
+    virtual void CreateAndSendJitBufMessage ( const int iCurChanID,
+                                              const int iNNumFra ) = 0;
+};
+
+template<>
+class CServerSlots<0> {};
+
+class CServer :
+        public QObject,
+        public CServerSlots<MAX_NUM_CHANNELS>
 {
     Q_OBJECT
 
@@ -210,10 +245,14 @@ protected:
     int FindChannel ( const CHostAddress& CheckAddr );
     int GetNumberOfConnectedClients();
     CVector<CChannelInfo> CreateChannelList();
-    void CreateAndSendChanListForAllConChannels();
-    void CreateAndSendChanListForThisChan ( const int iCurChanID );
-    void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
-                                                  const QString& strChatText );
+    virtual void CreateAndSendChanListForAllConChannels();
+    virtual void CreateAndSendChanListForThisChan ( const int iCurChanID );
+    virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
+                                                          const QString& strChatText );
+
+    virtual void CreateAndSendJitBufMessage ( const int iCurChanID,
+                                              const int iNNumFra );
+
     void WriteHTMLChannelList();
 
     void ProcessData ( const CVector<CVector<int16_t> >& vecvecsData,
@@ -301,6 +340,10 @@ protected:
     ELicenceType               eLicenceType;
     bool                       bDisconnectAllClients;
 
+private:
+    template<unsigned int slotId>
+    inline void connectChannelSignalsToServerSlots();
+
 signals:
     void Started();
     void Stopped();
@@ -314,8 +357,8 @@ signals:
 public slots:
     void OnTimer();
 
-    void OnSendProtMessage ( int              iChID,
-                             CVector<uint8_t> vecMessage );
+    virtual void SendProtMessage ( int              iChID,
+                                   CVector<uint8_t> vecMessage );
 
     void OnNewConnection ( int          iChID,
                            CHostAddress RecHostAddr );
@@ -380,262 +423,4 @@ public slots:
 
     void OnCLDisconnection ( CHostAddress InetAddr );
 
-
-    // CODE TAG: MAX_NUM_CHANNELS_TAG
-    // make sure we have MAX_NUM_CHANNELS connections!!!
-    // send message
-    void OnSendProtMessCh0  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 0,  mess ); }
-    void OnSendProtMessCh1  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 1,  mess ); }
-    void OnSendProtMessCh2  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 2,  mess ); }
-    void OnSendProtMessCh3  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 3,  mess ); }
-    void OnSendProtMessCh4  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 4,  mess ); }
-    void OnSendProtMessCh5  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 5,  mess ); }
-    void OnSendProtMessCh6  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 6,  mess ); }
-    void OnSendProtMessCh7  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 7,  mess ); }
-    void OnSendProtMessCh8  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 8,  mess ); }
-    void OnSendProtMessCh9  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 9,  mess ); }
-    void OnSendProtMessCh10 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 10, mess ); }
-    void OnSendProtMessCh11 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 11, mess ); }
-    void OnSendProtMessCh12 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 12, mess ); }
-    void OnSendProtMessCh13 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 13, mess ); }
-    void OnSendProtMessCh14 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 14, mess ); }
-    void OnSendProtMessCh15 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 15, mess ); }
-    void OnSendProtMessCh16 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 16, mess ); }
-    void OnSendProtMessCh17 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 17, mess ); }
-    void OnSendProtMessCh18 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 18, mess ); }
-    void OnSendProtMessCh19 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 19, mess ); }
-    void OnSendProtMessCh20 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 20, mess ); }
-    void OnSendProtMessCh21 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 21, mess ); }
-    void OnSendProtMessCh22 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 22, mess ); }
-    void OnSendProtMessCh23 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 23, mess ); }
-    void OnSendProtMessCh24 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 24, mess ); }
-    void OnSendProtMessCh25 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 25, mess ); }
-    void OnSendProtMessCh26 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 26, mess ); }
-    void OnSendProtMessCh27 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 27, mess ); }
-    void OnSendProtMessCh28 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 28, mess ); }
-    void OnSendProtMessCh29 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 29, mess ); }
-    void OnSendProtMessCh30 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 30, mess ); }
-    void OnSendProtMessCh31 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 31, mess ); }
-    void OnSendProtMessCh32 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 32, mess ); }
-    void OnSendProtMessCh33 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 33, mess ); }
-    void OnSendProtMessCh34 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 34, mess ); }
-    void OnSendProtMessCh35 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 35, mess ); }
-    void OnSendProtMessCh36 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 36, mess ); }
-    void OnSendProtMessCh37 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 37, mess ); }
-    void OnSendProtMessCh38 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 38, mess ); }
-    void OnSendProtMessCh39 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 39, mess ); }
-    void OnSendProtMessCh40 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 40, mess ); }
-    void OnSendProtMessCh41 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 41, mess ); }
-    void OnSendProtMessCh42 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 42, mess ); }
-    void OnSendProtMessCh43 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 43, mess ); }
-    void OnSendProtMessCh44 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 44, mess ); }
-    void OnSendProtMessCh45 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 45, mess ); }
-    void OnSendProtMessCh46 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 46, mess ); }
-    void OnSendProtMessCh47 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 47, mess ); }
-    void OnSendProtMessCh48 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 48, mess ); }
-    void OnSendProtMessCh49 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 49, mess ); }
-
-    void OnReqConnClientsListCh0()  { CreateAndSendChanListForThisChan ( 0  ); }
-    void OnReqConnClientsListCh1()  { CreateAndSendChanListForThisChan ( 1  ); }
-    void OnReqConnClientsListCh2()  { CreateAndSendChanListForThisChan ( 2  ); }
-    void OnReqConnClientsListCh3()  { CreateAndSendChanListForThisChan ( 3  ); }
-    void OnReqConnClientsListCh4()  { CreateAndSendChanListForThisChan ( 4  ); }
-    void OnReqConnClientsListCh5()  { CreateAndSendChanListForThisChan ( 5  ); }
-    void OnReqConnClientsListCh6()  { CreateAndSendChanListForThisChan ( 6  ); }
-    void OnReqConnClientsListCh7()  { CreateAndSendChanListForThisChan ( 7  ); }
-    void OnReqConnClientsListCh8()  { CreateAndSendChanListForThisChan ( 8  ); }
-    void OnReqConnClientsListCh9()  { CreateAndSendChanListForThisChan ( 9  ); }
-    void OnReqConnClientsListCh10() { CreateAndSendChanListForThisChan ( 10 ); }
-    void OnReqConnClientsListCh11() { CreateAndSendChanListForThisChan ( 11 ); }
-    void OnReqConnClientsListCh12() { CreateAndSendChanListForThisChan ( 12 ); }
-    void OnReqConnClientsListCh13() { CreateAndSendChanListForThisChan ( 13 ); }
-    void OnReqConnClientsListCh14() { CreateAndSendChanListForThisChan ( 14 ); }
-    void OnReqConnClientsListCh15() { CreateAndSendChanListForThisChan ( 15 ); }
-    void OnReqConnClientsListCh16() { CreateAndSendChanListForThisChan ( 16 ); }
-    void OnReqConnClientsListCh17() { CreateAndSendChanListForThisChan ( 17 ); }
-    void OnReqConnClientsListCh18() { CreateAndSendChanListForThisChan ( 18 ); }
-    void OnReqConnClientsListCh19() { CreateAndSendChanListForThisChan ( 19 ); }
-    void OnReqConnClientsListCh20() { CreateAndSendChanListForThisChan ( 20 ); }
-    void OnReqConnClientsListCh21() { CreateAndSendChanListForThisChan ( 21 ); }
-    void OnReqConnClientsListCh22() { CreateAndSendChanListForThisChan ( 22 ); }
-    void OnReqConnClientsListCh23() { CreateAndSendChanListForThisChan ( 23 ); }
-    void OnReqConnClientsListCh24() { CreateAndSendChanListForThisChan ( 24 ); }
-    void OnReqConnClientsListCh25() { CreateAndSendChanListForThisChan ( 25 ); }
-    void OnReqConnClientsListCh26() { CreateAndSendChanListForThisChan ( 26 ); }
-    void OnReqConnClientsListCh27() { CreateAndSendChanListForThisChan ( 27 ); }
-    void OnReqConnClientsListCh28() { CreateAndSendChanListForThisChan ( 28 ); }
-    void OnReqConnClientsListCh29() { CreateAndSendChanListForThisChan ( 29 ); }
-    void OnReqConnClientsListCh30() { CreateAndSendChanListForThisChan ( 30 ); }
-    void OnReqConnClientsListCh31() { CreateAndSendChanListForThisChan ( 31 ); }
-    void OnReqConnClientsListCh32() { CreateAndSendChanListForThisChan ( 32 ); }
-    void OnReqConnClientsListCh33() { CreateAndSendChanListForThisChan ( 33 ); }
-    void OnReqConnClientsListCh34() { CreateAndSendChanListForThisChan ( 34 ); }
-    void OnReqConnClientsListCh35() { CreateAndSendChanListForThisChan ( 35 ); }
-    void OnReqConnClientsListCh36() { CreateAndSendChanListForThisChan ( 36 ); }
-    void OnReqConnClientsListCh37() { CreateAndSendChanListForThisChan ( 37 ); }
-    void OnReqConnClientsListCh38() { CreateAndSendChanListForThisChan ( 38 ); }
-    void OnReqConnClientsListCh39() { CreateAndSendChanListForThisChan ( 39 ); }
-    void OnReqConnClientsListCh40() { CreateAndSendChanListForThisChan ( 40 ); }
-    void OnReqConnClientsListCh41() { CreateAndSendChanListForThisChan ( 41 ); }
-    void OnReqConnClientsListCh42() { CreateAndSendChanListForThisChan ( 42 ); }
-    void OnReqConnClientsListCh43() { CreateAndSendChanListForThisChan ( 43 ); }
-    void OnReqConnClientsListCh44() { CreateAndSendChanListForThisChan ( 44 ); }
-    void OnReqConnClientsListCh45() { CreateAndSendChanListForThisChan ( 45 ); }
-    void OnReqConnClientsListCh46() { CreateAndSendChanListForThisChan ( 46 ); }
-    void OnReqConnClientsListCh47() { CreateAndSendChanListForThisChan ( 47 ); }
-    void OnReqConnClientsListCh48() { CreateAndSendChanListForThisChan ( 48 ); }
-    void OnReqConnClientsListCh49() { CreateAndSendChanListForThisChan ( 49 ); }
-
-    void OnChanInfoHasChangedCh0()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh1()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh2()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh3()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh4()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh5()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh6()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh7()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh8()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh9()  { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh10() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh11() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh12() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh13() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh14() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh15() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh16() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh17() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh18() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh19() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh20() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh21() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh22() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh23() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh24() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh25() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh26() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh27() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh28() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh29() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh30() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh31() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh32() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh33() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh34() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh35() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh36() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh37() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh38() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh39() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh40() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh41() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh42() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh43() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh44() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh45() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh46() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh47() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh48() { CreateAndSendChanListForAllConChannels(); }
-    void OnChanInfoHasChangedCh49() { CreateAndSendChanListForAllConChannels(); }
-
-    void OnChatTextReceivedCh0  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 0,  strChatText ); }
-    void OnChatTextReceivedCh1  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 1,  strChatText ); }
-    void OnChatTextReceivedCh2  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 2,  strChatText ); }
-    void OnChatTextReceivedCh3  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 3,  strChatText ); }
-    void OnChatTextReceivedCh4  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 4,  strChatText ); }
-    void OnChatTextReceivedCh5  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 5,  strChatText ); }
-    void OnChatTextReceivedCh6  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 6,  strChatText ); }
-    void OnChatTextReceivedCh7  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 7,  strChatText ); }
-    void OnChatTextReceivedCh8  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 8,  strChatText ); }
-    void OnChatTextReceivedCh9  ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 9,  strChatText ); }
-    void OnChatTextReceivedCh10 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 10, strChatText ); }
-    void OnChatTextReceivedCh11 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 11, strChatText ); }
-    void OnChatTextReceivedCh12 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 12, strChatText ); }
-    void OnChatTextReceivedCh13 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 13, strChatText ); }
-    void OnChatTextReceivedCh14 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 14, strChatText ); }
-    void OnChatTextReceivedCh15 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 15, strChatText ); }
-    void OnChatTextReceivedCh16 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 16, strChatText ); }
-    void OnChatTextReceivedCh17 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 17, strChatText ); }
-    void OnChatTextReceivedCh18 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 18, strChatText ); }
-    void OnChatTextReceivedCh19 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 19, strChatText ); }
-    void OnChatTextReceivedCh20 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 20, strChatText ); }
-    void OnChatTextReceivedCh21 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 21, strChatText ); }
-    void OnChatTextReceivedCh22 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 22, strChatText ); }
-    void OnChatTextReceivedCh23 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 23, strChatText ); }
-    void OnChatTextReceivedCh24 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 24, strChatText ); }
-    void OnChatTextReceivedCh25 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 25, strChatText ); }
-    void OnChatTextReceivedCh26 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 26, strChatText ); }
-    void OnChatTextReceivedCh27 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 27, strChatText ); }
-    void OnChatTextReceivedCh28 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 28, strChatText ); }
-    void OnChatTextReceivedCh29 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 29, strChatText ); }
-    void OnChatTextReceivedCh30 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 30, strChatText ); }
-    void OnChatTextReceivedCh31 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 31, strChatText ); }
-    void OnChatTextReceivedCh32 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 32, strChatText ); }
-    void OnChatTextReceivedCh33 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 33, strChatText ); }
-    void OnChatTextReceivedCh34 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 34, strChatText ); }
-    void OnChatTextReceivedCh35 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 35, strChatText ); }
-    void OnChatTextReceivedCh36 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 36, strChatText ); }
-    void OnChatTextReceivedCh37 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 37, strChatText ); }
-    void OnChatTextReceivedCh38 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 38, strChatText ); }
-    void OnChatTextReceivedCh39 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 39, strChatText ); }
-    void OnChatTextReceivedCh40 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 40, strChatText ); }
-    void OnChatTextReceivedCh41 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 41, strChatText ); }
-    void OnChatTextReceivedCh42 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 42, strChatText ); }
-    void OnChatTextReceivedCh43 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 43, strChatText ); }
-    void OnChatTextReceivedCh44 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 44, strChatText ); }
-    void OnChatTextReceivedCh45 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 45, strChatText ); }
-    void OnChatTextReceivedCh46 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 46, strChatText ); }
-    void OnChatTextReceivedCh47 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 47, strChatText ); }
-    void OnChatTextReceivedCh48 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 48, strChatText ); }
-    void OnChatTextReceivedCh49 ( QString strChatText ) { CreateAndSendChatTextForAllConChannels ( 49, strChatText ); }
-
-    void OnServerAutoSockBufSizeChangeCh0  ( int iNNumFra ) { vecChannels[0].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh1  ( int iNNumFra ) { vecChannels[1].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh2  ( int iNNumFra ) { vecChannels[2].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh3  ( int iNNumFra ) { vecChannels[3].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh4  ( int iNNumFra ) { vecChannels[4].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh5  ( int iNNumFra ) { vecChannels[5].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh6  ( int iNNumFra ) { vecChannels[6].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh7  ( int iNNumFra ) { vecChannels[7].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh8  ( int iNNumFra ) { vecChannels[8].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh9  ( int iNNumFra ) { vecChannels[9].CreateJitBufMes  ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh10 ( int iNNumFra ) { vecChannels[10].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh11 ( int iNNumFra ) { vecChannels[11].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh12 ( int iNNumFra ) { vecChannels[12].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh13 ( int iNNumFra ) { vecChannels[13].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh14 ( int iNNumFra ) { vecChannels[14].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh15 ( int iNNumFra ) { vecChannels[15].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh16 ( int iNNumFra ) { vecChannels[16].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh17 ( int iNNumFra ) { vecChannels[17].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh18 ( int iNNumFra ) { vecChannels[18].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh19 ( int iNNumFra ) { vecChannels[19].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh20 ( int iNNumFra ) { vecChannels[20].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh21 ( int iNNumFra ) { vecChannels[21].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh22 ( int iNNumFra ) { vecChannels[22].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh23 ( int iNNumFra ) { vecChannels[23].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh24 ( int iNNumFra ) { vecChannels[24].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh25 ( int iNNumFra ) { vecChannels[25].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh26 ( int iNNumFra ) { vecChannels[26].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh27 ( int iNNumFra ) { vecChannels[27].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh28 ( int iNNumFra ) { vecChannels[28].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh29 ( int iNNumFra ) { vecChannels[29].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh30 ( int iNNumFra ) { vecChannels[30].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh31 ( int iNNumFra ) { vecChannels[31].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh32 ( int iNNumFra ) { vecChannels[32].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh33 ( int iNNumFra ) { vecChannels[33].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh34 ( int iNNumFra ) { vecChannels[34].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh35 ( int iNNumFra ) { vecChannels[35].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh36 ( int iNNumFra ) { vecChannels[36].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh37 ( int iNNumFra ) { vecChannels[37].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh38 ( int iNNumFra ) { vecChannels[38].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh39 ( int iNNumFra ) { vecChannels[39].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh40 ( int iNNumFra ) { vecChannels[40].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh41 ( int iNNumFra ) { vecChannels[41].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh42 ( int iNNumFra ) { vecChannels[42].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh43 ( int iNNumFra ) { vecChannels[43].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh44 ( int iNNumFra ) { vecChannels[44].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh45 ( int iNNumFra ) { vecChannels[45].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh46 ( int iNNumFra ) { vecChannels[46].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh47 ( int iNNumFra ) { vecChannels[47].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh48 ( int iNNumFra ) { vecChannels[48].CreateJitBufMes ( iNNumFra ); }
-    void OnServerAutoSockBufSizeChangeCh49 ( int iNNumFra ) { vecChannels[49].CreateJitBufMes ( iNNumFra ); }
 };


### PR DESCRIPTION
This change removes code bloat and allows the maximum number of supported clients to be adjusted in a single place rather than in multiple places.
Note that this change requires Qt5's new signal/slot syntax (https://wiki.qt.io/New_Signal_Slot_Syntax). The code will no longer compile using Qt4.