### PR TITLE
Refactor signal to slot connections using recursive templates

### DIFF
--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -102,7 +102,31 @@ signals:
 };
 
 
-class CAudioMixerBoard : public QScrollArea
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+template<unsigned int slotId>
+class CAudioMixerBoardSlots : public CAudioMixerBoardSlots<slotId - 1>
+{
+
+public:
+    void OnChGainValueChanged ( double dValue ) { UpdateGainValue ( slotId - 1, dValue ); }
+
+protected:
+    virtual void UpdateGainValue ( const int    iChannelIdx,
+                                   const double dValue ) = 0;
+};
+
+template<>
+class CAudioMixerBoardSlots<0> {};
+
+#else
+template<unsigned int slotId>
+class CAudioMixerBoardSlots {};
+
+#endif
+
+class CAudioMixerBoard :
+    public QScrollArea,
+    public CAudioMixerBoardSlots<MAX_NUM_CHANNELS>
 {
     Q_OBJECT
 
@@ -136,9 +160,6 @@ protected:
     void StoreFaderSettings ( CChannelFader* pChanFader );
     void UpdateSoloStates();
 
-    void OnGainValueChanged ( const int    iChannelIdx,
-                              const double dValue );
-
     CVector<CChannelFader*> vecpChanFader;
     QGroupBox*              pGroupBox;
     QHBoxLayout*            pMainLayout;
@@ -146,61 +167,77 @@ protected:
     bool                    bNoFaderVisible;
     QString                 strServerName;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    virtual void UpdateGainValue ( const int    iChannelIdx,
+                                   const double dValue );
+
+    template<unsigned int slotId>
+    inline void connectFaderSignalsToMixerBoardSlots();
+
+#else
+    void UpdateGainValue ( const int    iChannelIdx,
+                           const double dValue );
+
+#endif
+
+#if QT_VERSION < 0x50000  // MOC does not expand macros in Qt 4, so we cannot use QT_VERSION_CHECK(5, 0, 0)
 public slots:
     // CODE TAG: MAX_NUM_CHANNELS_TAG
     // make sure we have MAX_NUM_CHANNELS connections!!!
-    void OnGainValueChangedCh0  ( double dValue ) { OnGainValueChanged ( 0,  dValue ); }
-    void OnGainValueChangedCh1  ( double dValue ) { OnGainValueChanged ( 1,  dValue ); }
-    void OnGainValueChangedCh2  ( double dValue ) { OnGainValueChanged ( 2,  dValue ); }
-    void OnGainValueChangedCh3  ( double dValue ) { OnGainValueChanged ( 3,  dValue ); }
-    void OnGainValueChangedCh4  ( double dValue ) { OnGainValueChanged ( 4,  dValue ); }
-    void OnGainValueChangedCh5  ( double dValue ) { OnGainValueChanged ( 5,  dValue ); }
-    void OnGainValueChangedCh6  ( double dValue ) { OnGainValueChanged ( 6,  dValue ); }
-    void OnGainValueChangedCh7  ( double dValue ) { OnGainValueChanged ( 7,  dValue ); }
-    void OnGainValueChangedCh8  ( double dValue ) { OnGainValueChanged ( 8,  dValue ); }
-    void OnGainValueChangedCh9  ( double dValue ) { OnGainValueChanged ( 9,  dValue ); }
-    void OnGainValueChangedCh10 ( double dValue ) { OnGainValueChanged ( 10, dValue ); }
-    void OnGainValueChangedCh11 ( double dValue ) { OnGainValueChanged ( 11, dValue ); }
-    void OnGainValueChangedCh12 ( double dValue ) { OnGainValueChanged ( 12, dValue ); }
-    void OnGainValueChangedCh13 ( double dValue ) { OnGainValueChanged ( 13, dValue ); }
-    void OnGainValueChangedCh14 ( double dValue ) { OnGainValueChanged ( 14, dValue ); }
-    void OnGainValueChangedCh15 ( double dValue ) { OnGainValueChanged ( 15, dValue ); }
-    void OnGainValueChangedCh16 ( double dValue ) { OnGainValueChanged ( 16, dValue ); }
-    void OnGainValueChangedCh17 ( double dValue ) { OnGainValueChanged ( 17, dValue ); }
-    void OnGainValueChangedCh18 ( double dValue ) { OnGainValueChanged ( 18, dValue ); }
-    void OnGainValueChangedCh19 ( double dValue ) { OnGainValueChanged ( 19, dValue ); }
-    void OnGainValueChangedCh20 ( double dValue ) { OnGainValueChanged ( 20, dValue ); }
-    void OnGainValueChangedCh21 ( double dValue ) { OnGainValueChanged ( 21, dValue ); }
-    void OnGainValueChangedCh22 ( double dValue ) { OnGainValueChanged ( 22, dValue ); }
-    void OnGainValueChangedCh23 ( double dValue ) { OnGainValueChanged ( 23, dValue ); }
-    void OnGainValueChangedCh24 ( double dValue ) { OnGainValueChanged ( 24, dValue ); }
-    void OnGainValueChangedCh25 ( double dValue ) { OnGainValueChanged ( 25, dValue ); }
-    void OnGainValueChangedCh26 ( double dValue ) { OnGainValueChanged ( 26, dValue ); }
-    void OnGainValueChangedCh27 ( double dValue ) { OnGainValueChanged ( 27, dValue ); }
-    void OnGainValueChangedCh28 ( double dValue ) { OnGainValueChanged ( 28, dValue ); }
-    void OnGainValueChangedCh29 ( double dValue ) { OnGainValueChanged ( 29, dValue ); }
-    void OnGainValueChangedCh30 ( double dValue ) { OnGainValueChanged ( 30, dValue ); }
-    void OnGainValueChangedCh31 ( double dValue ) { OnGainValueChanged ( 31, dValue ); }
-    void OnGainValueChangedCh32 ( double dValue ) { OnGainValueChanged ( 32, dValue ); }
-    void OnGainValueChangedCh33 ( double dValue ) { OnGainValueChanged ( 33, dValue ); }
-    void OnGainValueChangedCh34 ( double dValue ) { OnGainValueChanged ( 34, dValue ); }
-    void OnGainValueChangedCh35 ( double dValue ) { OnGainValueChanged ( 35, dValue ); }
-    void OnGainValueChangedCh36 ( double dValue ) { OnGainValueChanged ( 36, dValue ); }
-    void OnGainValueChangedCh37 ( double dValue ) { OnGainValueChanged ( 37, dValue ); }
-    void OnGainValueChangedCh38 ( double dValue ) { OnGainValueChanged ( 38, dValue ); }
-    void OnGainValueChangedCh39 ( double dValue ) { OnGainValueChanged ( 39, dValue ); }
-    void OnGainValueChangedCh40 ( double dValue ) { OnGainValueChanged ( 40, dValue ); }
-    void OnGainValueChangedCh41 ( double dValue ) { OnGainValueChanged ( 41, dValue ); }
-    void OnGainValueChangedCh42 ( double dValue ) { OnGainValueChanged ( 42, dValue ); }
-    void OnGainValueChangedCh43 ( double dValue ) { OnGainValueChanged ( 43, dValue ); }
-    void OnGainValueChangedCh44 ( double dValue ) { OnGainValueChanged ( 44, dValue ); }
-    void OnGainValueChangedCh45 ( double dValue ) { OnGainValueChanged ( 45, dValue ); }
-    void OnGainValueChangedCh46 ( double dValue ) { OnGainValueChanged ( 46, dValue ); }
-    void OnGainValueChangedCh47 ( double dValue ) { OnGainValueChanged ( 47, dValue ); }
-    void OnGainValueChangedCh48 ( double dValue ) { OnGainValueChanged ( 48, dValue ); }
-    void OnGainValueChangedCh49 ( double dValue ) { OnGainValueChanged ( 49, dValue ); }
+    void OnGainValueChangedCh0  ( double dValue ) { UpdateGainValue ( 0,  dValue ); }
+    void OnGainValueChangedCh1  ( double dValue ) { UpdateGainValue ( 1,  dValue ); }
+    void OnGainValueChangedCh2  ( double dValue ) { UpdateGainValue ( 2,  dValue ); }
+    void OnGainValueChangedCh3  ( double dValue ) { UpdateGainValue ( 3,  dValue ); }
+    void OnGainValueChangedCh4  ( double dValue ) { UpdateGainValue ( 4,  dValue ); }
+    void OnGainValueChangedCh5  ( double dValue ) { UpdateGainValue ( 5,  dValue ); }
+    void OnGainValueChangedCh6  ( double dValue ) { UpdateGainValue ( 6,  dValue ); }
+    void OnGainValueChangedCh7  ( double dValue ) { UpdateGainValue ( 7,  dValue ); }
+    void OnGainValueChangedCh8  ( double dValue ) { UpdateGainValue ( 8,  dValue ); }
+    void OnGainValueChangedCh9  ( double dValue ) { UpdateGainValue ( 9,  dValue ); }
+    void OnGainValueChangedCh10 ( double dValue ) { UpdateGainValue ( 10, dValue ); }
+    void OnGainValueChangedCh11 ( double dValue ) { UpdateGainValue ( 11, dValue ); }
+    void OnGainValueChangedCh12 ( double dValue ) { UpdateGainValue ( 12, dValue ); }
+    void OnGainValueChangedCh13 ( double dValue ) { UpdateGainValue ( 13, dValue ); }
+    void OnGainValueChangedCh14 ( double dValue ) { UpdateGainValue ( 14, dValue ); }
+    void OnGainValueChangedCh15 ( double dValue ) { UpdateGainValue ( 15, dValue ); }
+    void OnGainValueChangedCh16 ( double dValue ) { UpdateGainValue ( 16, dValue ); }
+    void OnGainValueChangedCh17 ( double dValue ) { UpdateGainValue ( 17, dValue ); }
+    void OnGainValueChangedCh18 ( double dValue ) { UpdateGainValue ( 18, dValue ); }
+    void OnGainValueChangedCh19 ( double dValue ) { UpdateGainValue ( 19, dValue ); }
+    void OnGainValueChangedCh20 ( double dValue ) { UpdateGainValue ( 20, dValue ); }
+    void OnGainValueChangedCh21 ( double dValue ) { UpdateGainValue ( 21, dValue ); }
+    void OnGainValueChangedCh22 ( double dValue ) { UpdateGainValue ( 22, dValue ); }
+    void OnGainValueChangedCh23 ( double dValue ) { UpdateGainValue ( 23, dValue ); }
+    void OnGainValueChangedCh24 ( double dValue ) { UpdateGainValue ( 24, dValue ); }
+    void OnGainValueChangedCh25 ( double dValue ) { UpdateGainValue ( 25, dValue ); }
+    void OnGainValueChangedCh26 ( double dValue ) { UpdateGainValue ( 26, dValue ); }
+    void OnGainValueChangedCh27 ( double dValue ) { UpdateGainValue ( 27, dValue ); }
+    void OnGainValueChangedCh28 ( double dValue ) { UpdateGainValue ( 28, dValue ); }
+    void OnGainValueChangedCh29 ( double dValue ) { UpdateGainValue ( 29, dValue ); }
+    void OnGainValueChangedCh30 ( double dValue ) { UpdateGainValue ( 30, dValue ); }
+    void OnGainValueChangedCh31 ( double dValue ) { UpdateGainValue ( 31, dValue ); }
+    void OnGainValueChangedCh32 ( double dValue ) { UpdateGainValue ( 32, dValue ); }
+    void OnGainValueChangedCh33 ( double dValue ) { UpdateGainValue ( 33, dValue ); }
+    void OnGainValueChangedCh34 ( double dValue ) { UpdateGainValue ( 34, dValue ); }
+    void OnGainValueChangedCh35 ( double dValue ) { UpdateGainValue ( 35, dValue ); }
+    void OnGainValueChangedCh36 ( double dValue ) { UpdateGainValue ( 36, dValue ); }
+    void OnGainValueChangedCh37 ( double dValue ) { UpdateGainValue ( 37, dValue ); }
+    void OnGainValueChangedCh38 ( double dValue ) { UpdateGainValue ( 38, dValue ); }
+    void OnGainValueChangedCh39 ( double dValue ) { UpdateGainValue ( 39, dValue ); }
+    void OnGainValueChangedCh40 ( double dValue ) { UpdateGainValue ( 40, dValue ); }
+    void OnGainValueChangedCh41 ( double dValue ) { UpdateGainValue ( 41, dValue ); }
+    void OnGainValueChangedCh42 ( double dValue ) { UpdateGainValue ( 42, dValue ); }
+    void OnGainValueChangedCh43 ( double dValue ) { UpdateGainValue ( 43, dValue ); }
+    void OnGainValueChangedCh44 ( double dValue ) { UpdateGainValue ( 44, dValue ); }
+    void OnGainValueChangedCh45 ( double dValue ) { UpdateGainValue ( 45, dValue ); }
+    void OnGainValueChangedCh46 ( double dValue ) { UpdateGainValue ( 46, dValue ); }
+    void OnGainValueChangedCh47 ( double dValue ) { UpdateGainValue ( 47, dValue ); }
+    void OnGainValueChangedCh48 ( double dValue ) { UpdateGainValue ( 48, dValue ); }
+    void OnGainValueChangedCh49 ( double dValue ) { UpdateGainValue ( 49, dValue ); }
 
     void OnChSoloStateChanged() { UpdateSoloStates(); }
+
+#endif
 
 signals:
     void ChangeChanGain ( int iId, double dGain );

--- a/src/global.h
+++ b/src/global.h
@@ -175,9 +175,11 @@ LED bar:      lbr
 #define LOW_BOUND_SIG_METER              ( -50.0 ) // dB
 #define UPPER_BOUND_SIG_METER            ( 0.0 )   // dB
 
-// Maximum number of connected clients at the server. If you want to change this
-// paramter you have to modify the code on some places, too! The code tag
+// Maximum number of connected clients at the server.
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+// If you want to change this paramter you have to modify the code on some places, too! The code tag
 // "MAX_NUM_CHANNELS_TAG" shows these places (just search for the tag in the entire code)
+#endif
 #define MAX_NUM_CHANNELS                 50 // max number channels for server
 
 // actual number of used channels in the server

--- a/src/server.h
+++ b/src/server.h
@@ -116,7 +116,50 @@ signals:
 #endif
 
 
-class CServer : public QObject
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+template<unsigned int slotId>
+class CServerSlots : public CServerSlots<slotId - 1>
+{
+
+public:
+    void OnSendProtMessCh( CVector<uint8_t> mess ) { SendProtMessage ( slotId - 1,  mess ); }
+    void OnReqConnClientsListCh()  { CreateAndSendChanListForThisChan ( slotId - 1 ); }
+
+    void OnChatTextReceivedCh( QString strChatText )
+    {
+        CreateAndSendChatTextForAllConChannels ( slotId - 1, strChatText );
+    }
+
+    void OnServerAutoSockBufSizeChangeCh( int iNNumFra )
+    {
+        CreateAndSendJitBufMessage( slotId - 1, iNNumFra );
+    }
+
+protected:
+    virtual void SendProtMessage ( int              iChID,
+                                   CVector<uint8_t> vecMessage ) = 0;
+
+    virtual void CreateAndSendChanListForThisChan ( const int iCurChanID ) = 0;
+
+    virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
+                                                          const QString& strChatText ) = 0;
+
+    virtual void CreateAndSendJitBufMessage ( const int iCurChanID,
+                                              const int iNNumFra ) = 0;
+};
+
+template<>
+class CServerSlots<0> {};
+
+#else
+template<unsigned int slotId>
+class CServerSlots {};
+
+#endif
+
+class CServer :
+        public QObject,
+        public CServerSlots<MAX_NUM_CHANNELS>
 {
     Q_OBJECT
 
@@ -212,10 +255,33 @@ protected:
     int FindChannel ( const CHostAddress& CheckAddr );
     int GetNumberOfConnectedClients();
     CVector<CChannelInfo> CreateChannelList();
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    virtual void CreateAndSendChanListForAllConChannels();
+    virtual void CreateAndSendChanListForThisChan ( const int iCurChanID );
+    virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
+                                                          const QString& strChatText );
+
+    virtual void CreateAndSendJitBufMessage ( const int iCurChanID,
+                                              const int iNNumFra );
+
+    virtual void SendProtMessage ( int              iChID,
+                                   CVector<uint8_t> vecMessage );
+
+    template<unsigned int slotId>
+    inline void connectChannelSignalsToServerSlots();
+
+#else
     void CreateAndSendChanListForAllConChannels();
     void CreateAndSendChanListForThisChan ( const int iCurChanID );
     void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
                                                   const QString& strChatText );
+
+    void SendProtMessage ( int              iChID,
+                           CVector<uint8_t> vecMessage );
+
+#endif
+
     void WriteHTMLChannelList();
 
     void ProcessData ( const CVector<CVector<int16_t> >& vecvecsData,
@@ -317,9 +383,6 @@ signals:
 public slots:
     void OnTimer();
 
-    void OnSendProtMessage ( int              iChID,
-                             CVector<uint8_t> vecMessage );
-
     void OnNewConnection ( int          iChID,
                            CHostAddress RecHostAddr );
 
@@ -391,60 +454,60 @@ public slots:
 
     void OnCLDisconnection ( CHostAddress InetAddr );
 
-
+#if QT_VERSION < 0x50000  // MOC does not expand macros in Qt 4, so we cannot use QT_VERSION_CHECK(5, 0, 0)
     // CODE TAG: MAX_NUM_CHANNELS_TAG
     // make sure we have MAX_NUM_CHANNELS connections!!!
     // send message
-    void OnSendProtMessCh0  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 0,  mess ); }
-    void OnSendProtMessCh1  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 1,  mess ); }
-    void OnSendProtMessCh2  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 2,  mess ); }
-    void OnSendProtMessCh3  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 3,  mess ); }
-    void OnSendProtMessCh4  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 4,  mess ); }
-    void OnSendProtMessCh5  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 5,  mess ); }
-    void OnSendProtMessCh6  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 6,  mess ); }
-    void OnSendProtMessCh7  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 7,  mess ); }
-    void OnSendProtMessCh8  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 8,  mess ); }
-    void OnSendProtMessCh9  ( CVector<uint8_t> mess ) { OnSendProtMessage ( 9,  mess ); }
-    void OnSendProtMessCh10 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 10, mess ); }
-    void OnSendProtMessCh11 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 11, mess ); }
-    void OnSendProtMessCh12 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 12, mess ); }
-    void OnSendProtMessCh13 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 13, mess ); }
-    void OnSendProtMessCh14 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 14, mess ); }
-    void OnSendProtMessCh15 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 15, mess ); }
-    void OnSendProtMessCh16 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 16, mess ); }
-    void OnSendProtMessCh17 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 17, mess ); }
-    void OnSendProtMessCh18 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 18, mess ); }
-    void OnSendProtMessCh19 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 19, mess ); }
-    void OnSendProtMessCh20 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 20, mess ); }
-    void OnSendProtMessCh21 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 21, mess ); }
-    void OnSendProtMessCh22 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 22, mess ); }
-    void OnSendProtMessCh23 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 23, mess ); }
-    void OnSendProtMessCh24 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 24, mess ); }
-    void OnSendProtMessCh25 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 25, mess ); }
-    void OnSendProtMessCh26 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 26, mess ); }
-    void OnSendProtMessCh27 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 27, mess ); }
-    void OnSendProtMessCh28 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 28, mess ); }
-    void OnSendProtMessCh29 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 29, mess ); }
-    void OnSendProtMessCh30 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 30, mess ); }
-    void OnSendProtMessCh31 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 31, mess ); }
-    void OnSendProtMessCh32 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 32, mess ); }
-    void OnSendProtMessCh33 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 33, mess ); }
-    void OnSendProtMessCh34 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 34, mess ); }
-    void OnSendProtMessCh35 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 35, mess ); }
-    void OnSendProtMessCh36 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 36, mess ); }
-    void OnSendProtMessCh37 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 37, mess ); }
-    void OnSendProtMessCh38 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 38, mess ); }
-    void OnSendProtMessCh39 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 39, mess ); }
-    void OnSendProtMessCh40 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 40, mess ); }
-    void OnSendProtMessCh41 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 41, mess ); }
-    void OnSendProtMessCh42 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 42, mess ); }
-    void OnSendProtMessCh43 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 43, mess ); }
-    void OnSendProtMessCh44 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 44, mess ); }
-    void OnSendProtMessCh45 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 45, mess ); }
-    void OnSendProtMessCh46 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 46, mess ); }
-    void OnSendProtMessCh47 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 47, mess ); }
-    void OnSendProtMessCh48 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 48, mess ); }
-    void OnSendProtMessCh49 ( CVector<uint8_t> mess ) { OnSendProtMessage ( 49, mess ); }
+    void OnSendProtMessCh0  ( CVector<uint8_t> mess ) { SendProtMessage ( 0,  mess ); }
+    void OnSendProtMessCh1  ( CVector<uint8_t> mess ) { SendProtMessage ( 1,  mess ); }
+    void OnSendProtMessCh2  ( CVector<uint8_t> mess ) { SendProtMessage ( 2,  mess ); }
+    void OnSendProtMessCh3  ( CVector<uint8_t> mess ) { SendProtMessage ( 3,  mess ); }
+    void OnSendProtMessCh4  ( CVector<uint8_t> mess ) { SendProtMessage ( 4,  mess ); }
+    void OnSendProtMessCh5  ( CVector<uint8_t> mess ) { SendProtMessage ( 5,  mess ); }
+    void OnSendProtMessCh6  ( CVector<uint8_t> mess ) { SendProtMessage ( 6,  mess ); }
+    void OnSendProtMessCh7  ( CVector<uint8_t> mess ) { SendProtMessage ( 7,  mess ); }
+    void OnSendProtMessCh8  ( CVector<uint8_t> mess ) { SendProtMessage ( 8,  mess ); }
+    void OnSendProtMessCh9  ( CVector<uint8_t> mess ) { SendProtMessage ( 9,  mess ); }
+    void OnSendProtMessCh10 ( CVector<uint8_t> mess ) { SendProtMessage ( 10, mess ); }
+    void OnSendProtMessCh11 ( CVector<uint8_t> mess ) { SendProtMessage ( 11, mess ); }
+    void OnSendProtMessCh12 ( CVector<uint8_t> mess ) { SendProtMessage ( 12, mess ); }
+    void OnSendProtMessCh13 ( CVector<uint8_t> mess ) { SendProtMessage ( 13, mess ); }
+    void OnSendProtMessCh14 ( CVector<uint8_t> mess ) { SendProtMessage ( 14, mess ); }
+    void OnSendProtMessCh15 ( CVector<uint8_t> mess ) { SendProtMessage ( 15, mess ); }
+    void OnSendProtMessCh16 ( CVector<uint8_t> mess ) { SendProtMessage ( 16, mess ); }
+    void OnSendProtMessCh17 ( CVector<uint8_t> mess ) { SendProtMessage ( 17, mess ); }
+    void OnSendProtMessCh18 ( CVector<uint8_t> mess ) { SendProtMessage ( 18, mess ); }
+    void OnSendProtMessCh19 ( CVector<uint8_t> mess ) { SendProtMessage ( 19, mess ); }
+    void OnSendProtMessCh20 ( CVector<uint8_t> mess ) { SendProtMessage ( 20, mess ); }
+    void OnSendProtMessCh21 ( CVector<uint8_t> mess ) { SendProtMessage ( 21, mess ); }
+    void OnSendProtMessCh22 ( CVector<uint8_t> mess ) { SendProtMessage ( 22, mess ); }
+    void OnSendProtMessCh23 ( CVector<uint8_t> mess ) { SendProtMessage ( 23, mess ); }
+    void OnSendProtMessCh24 ( CVector<uint8_t> mess ) { SendProtMessage ( 24, mess ); }
+    void OnSendProtMessCh25 ( CVector<uint8_t> mess ) { SendProtMessage ( 25, mess ); }
+    void OnSendProtMessCh26 ( CVector<uint8_t> mess ) { SendProtMessage ( 26, mess ); }
+    void OnSendProtMessCh27 ( CVector<uint8_t> mess ) { SendProtMessage ( 27, mess ); }
+    void OnSendProtMessCh28 ( CVector<uint8_t> mess ) { SendProtMessage ( 28, mess ); }
+    void OnSendProtMessCh29 ( CVector<uint8_t> mess ) { SendProtMessage ( 29, mess ); }
+    void OnSendProtMessCh30 ( CVector<uint8_t> mess ) { SendProtMessage ( 30, mess ); }
+    void OnSendProtMessCh31 ( CVector<uint8_t> mess ) { SendProtMessage ( 31, mess ); }
+    void OnSendProtMessCh32 ( CVector<uint8_t> mess ) { SendProtMessage ( 32, mess ); }
+    void OnSendProtMessCh33 ( CVector<uint8_t> mess ) { SendProtMessage ( 33, mess ); }
+    void OnSendProtMessCh34 ( CVector<uint8_t> mess ) { SendProtMessage ( 34, mess ); }
+    void OnSendProtMessCh35 ( CVector<uint8_t> mess ) { SendProtMessage ( 35, mess ); }
+    void OnSendProtMessCh36 ( CVector<uint8_t> mess ) { SendProtMessage ( 36, mess ); }
+    void OnSendProtMessCh37 ( CVector<uint8_t> mess ) { SendProtMessage ( 37, mess ); }
+    void OnSendProtMessCh38 ( CVector<uint8_t> mess ) { SendProtMessage ( 38, mess ); }
+    void OnSendProtMessCh39 ( CVector<uint8_t> mess ) { SendProtMessage ( 39, mess ); }
+    void OnSendProtMessCh40 ( CVector<uint8_t> mess ) { SendProtMessage ( 40, mess ); }
+    void OnSendProtMessCh41 ( CVector<uint8_t> mess ) { SendProtMessage ( 41, mess ); }
+    void OnSendProtMessCh42 ( CVector<uint8_t> mess ) { SendProtMessage ( 42, mess ); }
+    void OnSendProtMessCh43 ( CVector<uint8_t> mess ) { SendProtMessage ( 43, mess ); }
+    void OnSendProtMessCh44 ( CVector<uint8_t> mess ) { SendProtMessage ( 44, mess ); }
+    void OnSendProtMessCh45 ( CVector<uint8_t> mess ) { SendProtMessage ( 45, mess ); }
+    void OnSendProtMessCh46 ( CVector<uint8_t> mess ) { SendProtMessage ( 46, mess ); }
+    void OnSendProtMessCh47 ( CVector<uint8_t> mess ) { SendProtMessage ( 47, mess ); }
+    void OnSendProtMessCh48 ( CVector<uint8_t> mess ) { SendProtMessage ( 48, mess ); }
+    void OnSendProtMessCh49 ( CVector<uint8_t> mess ) { SendProtMessage ( 49, mess ); }
 
     void OnReqConnClientsListCh0()  { CreateAndSendChanListForThisChan ( 0  ); }
     void OnReqConnClientsListCh1()  { CreateAndSendChanListForThisChan ( 1  ); }
@@ -649,4 +712,6 @@ public slots:
     void OnServerAutoSockBufSizeChangeCh47 ( int iNNumFra ) { vecChannels[47].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh48 ( int iNNumFra ) { vecChannels[48].CreateJitBufMes ( iNNumFra ); }
     void OnServerAutoSockBufSizeChangeCh49 ( int iNNumFra ) { vecChannels[49].CreateJitBufMes ( iNNumFra ); }
+
+#endif
 };


### PR DESCRIPTION
This change allows the maximum number of supported clients to be adjusted in a single place rather than in multiple places.
Note that this change requires Qt5's new signal/slot syntax (https://wiki.qt.io/New_Signal_Slot_Syntax), but is still backwards compatible with Qt4.
Code bloat will be eventually reduced by removing support for Qt4.

Supersedes https://github.com/corrados/jamulus/pull/88.