### PR TITLE
link the server installation from README.md as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Compilation and Development
 See the these [compile Instructions](INSTALL.md) 
 
 For server instructions, see [server manual](src/res/homepage/servermanual.md)
+and the [server documentation](https://github.com/corrados/jamulus/wiki/Running-a-Server).
 
 
 Acknowledgments


### PR DESCRIPTION
so we don’t need to install `INSTALL.md` in the Debian binary package (all except this one link is only needed for the from-source installation)