### PR TITLE
Allow client to bind on a random port

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -54,23 +54,35 @@ void CSocket::Init ( const quint16 iPortNumber )
 
     if ( bIsClient )
     {
-        // Per definition use the port number plus ten for the client to make
-        // it possible to run server and client on the same computer. If the
-        // port is not available, try "NUM_SOCKET_PORTS_TO_TRY" times with
-        // incremented port numbers
-        quint16 iClientPortIncrement = 10; // start value: port nubmer plus ten
-        bSuccess                     = false; // initialization for while loop
-
-        while ( !bSuccess &&
-                ( iClientPortIncrement <= NUM_SOCKET_PORTS_TO_TRY ) )
+        if (iPortNumber == 0)
         {
-            UdpSocketInAddr.sin_port = htons ( iPortNumber + iClientPortIncrement );
+            // If port number is 0, bind the client to a random available port.
+            UdpSocketInAddr.sin_port = htons ( iPortNumber );
 
             bSuccess = ( ::bind ( UdpSocket ,
-                                  (sockaddr*) &UdpSocketInAddr,
-                                  sizeof ( sockaddr_in ) ) == 0 );
+                                (sockaddr*) &UdpSocketInAddr,
+                                sizeof ( sockaddr_in ) ) == 0 );
+        }
+        else
+        {
+            // Per definition use the port number plus ten for the client to make
+            // it possible to run server and client on the same computer. If the
+            // port is not available, try "NUM_SOCKET_PORTS_TO_TRY" times with
+            // incremented port numbers
+            quint16 iClientPortIncrement = 10; // start value: port nubmer plus ten
+            bSuccess                     = false; // initialization for while loop
 
-            iClientPortIncrement++;
+            while ( !bSuccess &&
+                    ( iClientPortIncrement <= NUM_SOCKET_PORTS_TO_TRY ) )
+            {
+                UdpSocketInAddr.sin_port = htons ( iPortNumber + iClientPortIncrement );
+
+                bSuccess = ( ::bind ( UdpSocket ,
+                                    (sockaddr*) &UdpSocketInAddr,
+                                    sizeof ( sockaddr_in ) ) == 0 );
+
+                iClientPortIncrement++;
+            }
         }
     }
     else

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -57,7 +57,7 @@ void CSocket::Init ( const quint16 iPortNumber )
         if (iPortNumber == 0)
         {
             // If port number is 0, bind the client to a random available port.
-            UdpSocketInAddr.sin_port = htons ( iPortNumber );
+            UdpSocketInAddr.sin_port = htons ( 0 );
 
             bSuccess = ( ::bind ( UdpSocket ,
                                 (sockaddr*) &UdpSocketInAddr,
@@ -88,7 +88,7 @@ void CSocket::Init ( const quint16 iPortNumber )
     else
     {
         // for the server, only try the given port number and do not try out
-        // other port numbers to bind since it is imporatant that the server
+        // other port numbers to bind since it is important that the server
         // gets the desired port number
         UdpSocketInAddr.sin_port = htons ( iPortNumber );
 


### PR DESCRIPTION
I some cases, we just want to run the Jamulus client on a random available port on our computer. :)

This PR prevents the 0 value to be incremented, so we can let the system choose a port for us.