### PR TITLE
Use a sortable and more standard datetime logging format

### DIFF
--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -11,7 +11,7 @@ override_dh_usrlocal:
 	install -D -m 0755 jamulus $$(pwd)/debian/jamulus/usr/bin/
 	mkdir -p $$(pwd)/debian/jamulus/usr/share/applications/
 	install -D -m 0755 $$(pwd)/distributions/jamulus.desktop $$(pwd)/debian/jamulus/usr/share/applications/
-	mkdir -p $$(pwd)/debian/jamulus/usr/share/icons/hicolor/48x48/apps/
+	mkdir -p $$(pwd)/debian/jamulus/usr/share/icons/hicolor/512x512/apps/
 	cp $$(pwd)/distributions/jamulus.png $$(pwd)/debian/jamulus/usr/share/icons/hicolor/512x512/apps/
 	mkdir -p $$(pwd)/debian/jamulus/lib/systemd/system
 	cp $$(pwd)/distributions/jamulus-server.service $$(pwd)/debian/jamulus/lib/systemd/system/

--- a/src/serverlogging.cpp
+++ b/src/serverlogging.cpp
@@ -118,24 +118,17 @@ void CServerLogging::ParseLogFile ( const QString& strFileName )
         QStringList strlistCurLine = strCurLine.split ( "," );
 
         // check number of separated strings condition
-        if ( strlistCurLine.size() == 4 )
+        if ( strlistCurLine.size() == 3 )
         {
             // first entry
-            QDate curDate =
-                QDate::fromString ( strlistCurLine.at ( 0 ).trimmed(),
-                "d.M.yyyy" );
+            QDateTime curDateTime =
+                QDateTime::fromString ( strlistCurLine.at ( 0 ).trimmed(),
+                "yyyy-MM-dd HH:mm:ss" );
 
-            // second entry
-            QTime curTime =
-                QTime::fromString ( strlistCurLine.at ( 1 ).trimmed(),
-                "hh:mm:ss" );
-
-            if ( curDate.isValid() && curTime.isValid() )
+            if ( curDateTime.isValid() )
             {
-                QDateTime curDateTime ( curDate, curTime );
-
                 // check if server stop or new client connection
-                QString strAddress = strlistCurLine.at ( 2 ).trimmed();
+                QString strAddress = strlistCurLine.at ( 1 ).trimmed();
 
                 if ( strAddress.isEmpty() )
                 {
@@ -147,8 +140,8 @@ void CServerLogging::ParseLogFile ( const QString& strFileName )
                 {
                     QHostAddress curAddress;
                     
-                    // third entry is IP address
-                    if ( curAddress.setAddress ( strlistCurLine.at ( 2 ).trimmed() ) )
+                    // second entry is IP address
+                    if ( curAddress.setAddress ( strlistCurLine.at ( 1 ).trimmed() ) )
                     {
                         // new client connection
                         JpegHistoryGraph.Add ( curDateTime, curAddress );
@@ -168,9 +161,6 @@ QString CServerLogging::CurTimeDatetoLogString()
     // time and date to string conversion
     const QDateTime curDateTime = QDateTime::currentDateTime();
 
-    // format date and time output according to "3.9.2006, 11:38:08"
-    return QString().setNum ( curDateTime.date().day() ) + "." +
-        QString().setNum ( curDateTime.date().month() ) + "." +
-        QString().setNum ( curDateTime.date().year() ) + ", " +
-        curDateTime.time().toString();
+    // format date and time output according to "2006-09-30 11:38:08"
+    return curDateTime.toString("yyyy-MM-dd HH:mm:ss");
 }


### PR DESCRIPTION
The current format (`d.M.yyyy, HH:mm:ss`) resembles the old pre-ISO-8601 German format, except it omitted the mandatory leading zeroes, worsening the already bad sortability.

Change to `yyyy-MM-dd HH:mm:ss` which is ISO but with a space instead of the letter `T` in the middle, as is common for cross-national (and even increasingly common for national) use and perfectly sortable.

I also squeezed in a fixup for commit e2014956355a578b7df0691d3614fca669c14ab7 which I noticed too late, i.e. after #102 was already merged (to my excuse, in the Debian package I’m working on the path only shows up on one line), as to not overflow you with MRs.