### PR TITLE
Address part of the licence dialogue

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -560,10 +560,6 @@ int main ( int argc, char** argv )
                              eLicenceType );
             if ( bUseGUI )
             {
-                // special case for the GUI mode: we want the licence type to be
-                // creative commons per default (if not given in the settings file)
-                Server.SetLicenceType ( LT_CREATIVECOMMONS );
-
                 // load settings from init-file
                 CSettings Settings ( &Server, strIniFileName );
                 Settings.Load();

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -58,8 +58,8 @@ CServerDlg::CServerDlg ( CServer*        pNServP,
 
     // CC licence dialog switch
     chbUseCCLicence->setWhatsThis ( tr ( "<b>Show Creative Commons Licence "
-        "Dialog:</b> If enabled, a Creative Commons Licence dialog is shown "
-        "each time a new user connects the server." ) );
+        "Dialog:</b> If enabled, a Creative Commons BY-NC-SA 4.0 Licence "
+        "dialog is shown each time a new user connects the server." ) );
 
     // Make My Server Public flag
     chbRegisterServer->setWhatsThis ( tr ( "<b>Make My Server Public:</b> If "

--- a/src/serverdlgbase.ui
+++ b/src/serverdlgbase.ui
@@ -56,7 +56,7 @@
    <item>
     <widget class="QCheckBox" name="chbUseCCLicence">
      <property name="text">
-      <string>Show Creative Commons Licence Dialog</string>
+      <string>Show Creative Commons BY-NC-SA 4.0 Licence Dialog</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
 - mention _which_ Creative Commons licence is used (CC-BY-NC-SA 4.0)
 - do not default to enable the checkbox on GUI server start

Advances, but does not completely close, #100 