### PR TITLE
Add some logging to the central server

### DIFF
--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -207,6 +207,8 @@ protected:
     // count of registration retries
     int                     iSvrRegRetries;
 
+    QTextStream& tsConsoleStream;
+
 public slots:
     void OnTimerPollList();
     void OnTimerPingServerInList();


### PR DESCRIPTION
Mostly for debugging but servers now log when they're making the requests, so having the central server log when it's handling them seems "fair" :).