### PR TITLE
--clientname command line option lets you set the Jamulus window title and jack client name.

### DIFF
--- a/android/sound.cpp
+++ b/android/sound.cpp
@@ -26,11 +26,12 @@
 
 
 /* Implementation *************************************************************/
-CSound::CSound ( void       (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
-                 void*      arg,
-                 const int  iCtrlMIDIChannel,
-                 const bool bNoAutoJackConnect ) :
-    CSoundBase ( "OpenSL", true, fpNewProcessCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect )
+CSound::CSound ( void             (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
+                 void*            arg,
+                 const int        iCtrlMIDIChannel,
+                 const bool       bNoAutoJackConnect,
+                 const QString&   strJackClientName ) :
+    CSoundBase ( "OpenSL", true, fpNewProcessCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect, strJackClientName )
 {
 
 }

--- a/android/sound.h
+++ b/android/sound.h
@@ -35,10 +35,11 @@
 class CSound : public CSoundBase
 {
 public:
-    CSound ( void       (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
-             void*      arg,
-             const int  iCtrlMIDIChannel,
-             const bool bNoAutoJackConnect );
+    CSound ( void             (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
+             void*            arg,
+             const int        iCtrlMIDIChannel,
+             const bool       bNoAutoJackConnect,
+             const QString&   strJackClientName );
     virtual ~CSound() {}
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );

--- a/linux/sound.cpp
+++ b/linux/sound.cpp
@@ -27,12 +27,12 @@
 #include "sound.h"
 
 #ifdef WITH_SOUND
-void CSound::OpenJack()
+void CSound::OpenJack(char* jackClientName)
 {
     jack_status_t JackStatus;
 
     // try to become a client of the JACK server
-    pJackClient = jack_client_open ( APP_NAME, JackNullOption, &JackStatus );
+    pJackClient = jack_client_open ( jackClientName, JackNullOption, &JackStatus );
 
     if ( pJackClient == nullptr )
     {

--- a/linux/sound.h
+++ b/linux/sound.h
@@ -63,9 +63,9 @@ public:
     CSound ( void       (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*      arg,
              const int  iCtrlMIDIChannel,
-             const bool bNoAutoJackConnect ) :
-        CSoundBase ( "Jack", true, fpNewProcessCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect ), iJACKBufferSizeMono ( 0 ),
-        iJACKBufferSizeStero ( 0 ) { OpenJack(); }
+             const bool bNoAutoJackConnect,
+             const QString&   strJackClientName ) :
+        CSoundBase ( "Jack", true, fpNewProcessCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect, strJackClientName ), iJACKBufferSizeMono ( 0 ) { OpenJack( strJackClientName.toLocal8Bit().data() ); }
     virtual ~CSound() { CloseJack(); }
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );
@@ -85,7 +85,7 @@ public:
     jack_port_t*   input_port_midi;
 
 protected:
-    void OpenJack();
+    void OpenJack(char* jackClientName);
     void CloseJack();
 
     // callbacks
@@ -99,11 +99,12 @@ protected:
 class CSound : public CSoundBase
 {
 public:
-    CSound ( void       (*fpNewProcessCallback) ( CVector<short>& psData, void* pParg ),
-             void*      pParg,
-             const int  iCtrlMIDIChannel,
-             const bool bNoAutoJackConnect ) :
-        CSoundBase ( "nosound", false, fpNewProcessCallback, pParg, iCtrlMIDIChannel, bNoAutoJackConnect ) {}
+    CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* pParg ),
+             void*          pParg,
+             const int      iCtrlMIDIChannel,
+             const bool     bNoAutoJackConnect,
+             const QString& strJackClientName ) :
+        CSoundBase ( "nosound", false, fpNewProcessCallback, pParg, iCtrlMIDIChannel, bNoAutoJackConnect, strJackClientName ) {}
     virtual ~CSound() {}
 };
 #endif // WITH_SOUND

--- a/mac/sound.cpp
+++ b/mac/sound.cpp
@@ -29,8 +29,9 @@
 CSound::CSound ( void       (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
                  void*      arg,
                  const int  iCtrlMIDIChannel,
-                 const bool bNoAutoJackConnect ) :
-    CSoundBase ( "CoreAudio", true, fpNewProcessCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect ),
+                 const bool bNoAutoJackConnect,
+                 QString&   strJackClientName ) :
+    CSoundBase ( "CoreAudio", true, fpNewProcessCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect, strJackClientName ),
     midiInPortRef ( static_cast<MIDIPortRef> ( NULL ) )
 {
     // Apple Mailing Lists: Subject: GUI Apps should set kAudioHardwarePropertyRunLoop

--- a/mac/sound.h
+++ b/mac/sound.h
@@ -36,10 +36,11 @@
 class CSound : public CSoundBase
 {
 public:
-    CSound ( void       (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
-             void*      arg,
-             const int  iCtrlMIDIChannel,
-             const bool bNoAutoJackConnect );
+    CSound ( void             (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
+             void*            arg,
+             const int        iCtrlMIDIChannel,
+             const bool       bNoAutoJackConnect,
+             const QString&   strJackClientName );
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );
     virtual void Start();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -29,7 +29,8 @@
 CClient::CClient ( const quint16  iPortNumber,
                    const QString& strConnOnStartupAddress,
                    const int      iCtrlMIDIChannel,
-                   const bool     bNoAutoJackConnect ) :
+                   const bool     bNoAutoJackConnect,
+                   const QString& strClientName ) :
     vstrIPAddress                    ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
     ChannelInfo                      (),
     vecStoredFaderTags               ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
@@ -59,7 +60,7 @@ CClient::CClient ( const quint16  iPortNumber,
     bIsInitializationPhase           ( true ),
     bMuteOutStream                   ( false ),
     Socket                           ( &Channel, iPortNumber ),
-    Sound                            ( AudioCallback, this, iCtrlMIDIChannel, bNoAutoJackConnect ),
+    Sound                            ( AudioCallback, this, iCtrlMIDIChannel, bNoAutoJackConnect, strClientName ),
     iAudioInFader                    ( AUD_FADER_IN_MIDDLE ),
     bReverbOnLeftChan                ( false ),
     iReverbLevel                     ( 0 ),
@@ -76,8 +77,12 @@ CClient::CClient ( const quint16  iPortNumber,
     bJitterBufferOK                  ( true ),
     strCentralServerAddress          ( "" ),
     eCentralServerAddressType        ( AT_DEFAULT ),
-    iServerSockBufNumFrames          ( DEF_NET_BUF_SIZE_NUM_BL )
+    iServerSockBufNumFrames          ( DEF_NET_BUF_SIZE_NUM_BL ),
+    strClientName                    ( APP_NAME )
 {
+    
+    SetClientName ( strClientName );
+    
     int iOpusError;
 
     OpusMode = opus_custom_mode_create ( SYSTEM_SAMPLE_RATE_HZ,

--- a/src/client.h
+++ b/src/client.h
@@ -107,12 +107,18 @@ public:
     CClient ( const quint16  iPortNumber,
               const QString& strConnOnStartupAddress,
               const int      iCtrlMIDIChannel,
-              const bool     bNoAutoJackConnect );
+              const bool     bNoAutoJackConnect,
+              const QString& strClientName );
 
     void   Start();
     void   Stop();
     bool   IsRunning() { return Sound.IsRunning(); }
     bool   SetServerAddr ( QString strNAddr );
+
+    QString GetClientName() const { return this->strClientName; }
+    void SetClientName ( const QString& strClientName ) {
+        this->strClientName = strClientName;
+    }
 
     double MicLeveldB_L() { return SignalLevelMeter.MicLeveldBLeft(); }
     double MicLeveldB_R() { return SignalLevelMeter.MicLeveldBRight(); }
@@ -383,6 +389,8 @@ protected:
 
     // for ping measurement
     CPreciseTime            PreciseTime;
+    
+    QString                 strClientName;
 
 public slots:
     void OnSendProtMessage ( CVector<uint8_t> vecMessage );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -802,24 +802,24 @@ void CClientDlg::OnNumClientsChanged ( int iNewNumClients )
     SetMyWindowTitle ( iNewNumClients );
 }
 
-void CClientDlg::SetMyWindowTitle ( const int iNumClients )
+void CClientDlg::SetMyWindowTitle ( const int iNumClients)
 {
     // show number of connected clients in window title (and therefore also in
     // the task bar of the OS)
     if ( iNumClients == 0 )
     {
         // only application name
-        setWindowTitle ( APP_NAME );
+        setWindowTitle ( pClient->GetClientName() );
     }
     else
     {
         if ( iNumClients == 1 )
         {
-            setWindowTitle ( QString ( APP_NAME ) + " (1 user)" );
+            setWindowTitle ( QString ( pClient->GetClientName() ) + " (1 user)" );
         }
         else
         {
-            setWindowTitle ( QString ( APP_NAME ) +
+            setWindowTitle ( QString ( pClient->GetClientName() ) +
                 QString ( " (%1 users)" ).arg ( iNumClients ) );
         }
     }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -95,6 +95,7 @@ protected:
     CClient*           pClient;
     CSettings*         pSettings;
 
+    QString            strClientName;
     bool               bConnected;
     bool               bConnectDlgWasShown;
     QTimer             TimerSigMet;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@ int main ( int argc, char** argv )
     QString      strCentralServer          = "";
     QString      strServerInfo             = "";
     QString      strWelcomeMessage         = "";
+    QString      strClientName             = APP_NAME;
 
     // QT docu: argv()[0] is the program name, argv()[1] is the first
     // argument and argv()[argc()-1] is the last argument.
@@ -431,6 +432,19 @@ int main ( int argc, char** argv )
             continue;
         }
 
+        // Client Name ---------------------------------------------------------
+        if ( GetStringArgument ( tsConsole,
+                                 argc,
+                                 argv,
+                                 i,
+                                 "--clientname",
+                                 "--clientname",
+                                 strArgument ) )
+        {
+            strClientName = strArgument;
+            tsConsole << "- client name: " << strClientName << endl;
+            continue;
+        }
 
         // Version number ------------------------------------------------------
         if ( ( !strcmp ( argv[i], "--version" ) ) ||
@@ -472,7 +486,6 @@ int main ( int argc, char** argv )
     {
         strCentralServer = DEFAULT_SERVER_ADDRESS;
     }
-
 
     // Application/GUI setup ---------------------------------------------------
     // Application object
@@ -523,7 +536,8 @@ int main ( int argc, char** argv )
             CClient Client ( iPortNumber,
                              strConnOnStartupAddress,
                              iCtrlMIDIChannel,
-                             bNoAutoJackConnect );
+                             bNoAutoJackConnect,
+                             strClientName );
 
             // load settings from init-file
             CSettings Settings ( &Client, strIniFileName );
@@ -672,7 +686,8 @@ QString UsageArguments ( char **argv )
         "                        name (server only)\n"
         "  -D, --histdays        number of days of history to display (server only)\n"
         "  -z, --startminimized  start minimizied (server only)\n"
-        "  --ctrlmidich          MIDI controller channel to listen (client only)"
+        "  --ctrlmidich          MIDI controller channel to listen (client only)\n"
+        "  --clientname          Jamulus client name (windows title and jack client name)\n"
         "\nExample: " + QString ( argv[0] ) + " -l -inifile myinifile.ini\n";
 }
 

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -31,13 +31,15 @@ CSoundBase::CSoundBase ( const QString& strNewSystemDriverTechniqueName,
                          void           (*fpNewProcessCallback) ( CVector<int16_t>& psData, void* pParg ),
                          void*          pParg,
                          const int      iNewCtrlMIDIChannel,
-                         const bool     bNewNoAutoJackConnect ) :
+                         const bool     bNewNoAutoJackConnect,
+                         const QString& strNewJackClientName ) :
     fpProcessCallback ( fpNewProcessCallback ),
     pProcessCallbackArg ( pParg ), bRun ( false ),
     bIsCallbackAudioInterface ( bNewIsCallbackAudioInterface ),
     strSystemDriverTechniqueName ( strNewSystemDriverTechniqueName ),
     iCtrlMIDIChannel ( iNewCtrlMIDIChannel ),
-    bNoAutoJackConnect ( bNewNoAutoJackConnect )
+    bNoAutoJackConnect ( bNewNoAutoJackConnect ),
+    strJackClientName ( strNewJackClientName )
 {
     // initializations for the sound card names (default)
     lNumDevs          = 1;

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -52,7 +52,8 @@ public:
                  void           (*fpNewProcessCallback) ( CVector<int16_t>& psData, void* pParg ),
                  void*          pParg,
                  const int      iNewCtrlMIDIChannel,
-                 const bool     bNewNoAutoJackConnect );
+                 const bool     bNewNoAutoJackConnect,
+                 const QString& strNewJackClientName );
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );
     virtual void Start();
@@ -122,6 +123,7 @@ protected:
     QString          strSystemDriverTechniqueName;
     int              iCtrlMIDIChannel;
     bool             bNoAutoJackConnect;
+    QString          strJackClientName;
 
     CVector<int16_t> vecsAudioSndCrdStereo;
 

--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -486,8 +486,9 @@ void CSound::Stop()
 CSound::CSound ( void       (*fpNewCallback) ( CVector<int16_t>& psData, void* arg ),
                  void*      arg,
                  const int  iCtrlMIDIChannel,
-                 const bool bNoAutoJackConnect) :
-    CSoundBase              ( "ASIO", true, fpNewCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect ),
+                 const bool bNoAutoJackConnect,
+                 const QString&   strJackClientName ) :
+    CSoundBase      ( "ASIO", true, fpNewCallback, arg, iCtrlMIDIChannel, bNoAutoJackConnect, strJackClientName ),
     lNumInChan              ( 0 ),
     lNumInChanPlusAddChan   ( 0 ),
     lNumOutChan             ( 0 ),

--- a/windows/sound.h
+++ b/windows/sound.h
@@ -49,7 +49,9 @@ public:
     CSound ( void       (*fpNewCallback) ( CVector<int16_t>& psData, void* arg ),
              void*      arg,
              const int  iCtrlMIDIChannel,
-             const bool bNoAutoJackConnect );
+             const bool bNoAutoJackConnect,
+             const QString&   strJackClientName );
+    
     virtual ~CSound() { UnloadCurrentDriver(); }
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );


### PR DESCRIPTION
--clientname command line option lets you set the Jamulus window title and jack client name.
Use example : 
Jamulus --clientname "Jamulus Paula"

if the --clientname is not set, APP_NAME is used.

Jamulus --help added the --clientname description.

I tested only Linux binaries.