### PR TITLE
deb packaging: build translations at build time

### DIFF
--- a/distributions/debian/control
+++ b/distributions/debian/control
@@ -11,6 +11,7 @@ Build-Depends:
  make,
  qt5-default,
  qtdeclarative5-dev,
+ qttools5-dev-tools,
 Standards-Version: 3.9.5
 Homepage: http://llcon.sourceforge.net/
 Vcs-Git: git://github.com/corrados/jamulus.git

--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -5,6 +5,10 @@
 override_dh_auto_configure:
 	qmake CONFIG+=noupcasename Jamulus.pro
 
+override_dh_auto_build:
+	cd src/res/translation && lrelease *.ts
+	dh_auto_build
+
 override_dh_usrlocal:
 	echo $$(pwd)
 	mkdir -p $$(pwd)/debian/jamulus/usr/bin/


### PR DESCRIPTION
This allows to build the translation right at build time, then ensuring that the qm files are always up-to-date with the ts files.