### PR TITLE
Feature/clip led

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -323,7 +323,7 @@ HEADERS += src/audiomixerboard.h \
     src/clientdlg.h \
     src/serverdlg.h \
     src/multicolorled.h \
-    src/multicolorledbar.h \
+    src/levelmeter.h \
     src/protocol.h \
     src/server.h \
     src/serverlist.h \
@@ -446,7 +446,7 @@ SOURCES += src/audiomixerboard.cpp \
     src/serverdlg.cpp \
     src/main.cpp \
     src/multicolorled.cpp \
-    src/multicolorledbar.cpp \
+    src/levelmeter.cpp \
     src/protocol.cpp \
     src/server.cpp \
     src/serverlist.cpp \

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -57,6 +57,7 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
 
     // setup channel level
     plbrChannelLevel->setContentsMargins ( 0, 3, 2, 3 );
+    plbrChannelLevel->SetClipTimeout ( 10000 );
 
     // setup slider
     pFader->setPageStep     ( 1 );

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -37,7 +37,7 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     pFrame                      = new QFrame            ( pNW );
 
     pLevelsBox                  = new QWidget           ( pFrame );
-    plbrChannelLevel            = new CMultiColorLEDBar ( pLevelsBox );
+    plbrChannelLevel            = new CLevelMeter       ( pLevelsBox );
     pFader                      = new QSlider           ( Qt::Vertical, pLevelsBox );
 
     pMuteSoloBox                = new QWidget           ( pFrame );
@@ -174,7 +174,7 @@ void CChannelFader::SetGUIDesign ( const EGUIDesign eNewDesign )
 
         pcbMute->setText                    ( tr ( "MUTE" ) );
         pcbSolo->setText                    ( tr ( "SOLO" ) );
-        plbrChannelLevel->SetLevelMeterType ( CMultiColorLEDBar::MT_LED );
+        plbrChannelLevel->SetLevelMeterType ( CLevelMeter::MT_LED );
         break;
 
     default:
@@ -182,7 +182,7 @@ void CChannelFader::SetGUIDesign ( const EGUIDesign eNewDesign )
         pFader->setStyleSheet               ( "" );
         pcbMute->setText                    ( tr ( "Mute" ) );
         pcbSolo->setText                    ( tr ( "Solo" ) );
-        plbrChannelLevel->SetLevelMeterType ( CMultiColorLEDBar::MT_BAR );
+        plbrChannelLevel->SetLevelMeterType ( CLevelMeter::MT_BAR );
         break;
     }
 }
@@ -249,7 +249,7 @@ void CChannelFader::Reset()
     // reset mute/solo check boxes and level meter
     pcbMute->setChecked ( false );
     pcbSolo->setChecked ( false );
-    plbrChannelLevel->setValue ( 0 );
+    plbrChannelLevel->Reset();
 
     // clear instrument picture, country flag, tool tips and label text
     plblLabel->setText ( "" );
@@ -348,7 +348,7 @@ void CChannelFader::UpdateSoloState ( const bool bNewOtherSoloState )
 
 void CChannelFader::SetChannelLevel ( const uint16_t iLevel )
 {
-    plbrChannelLevel->setValue ( iLevel );
+    plbrChannelLevel->SetValue ( iLevel );
 }
 
 void CChannelFader::SetText ( const CChannelInfo& ChanInfo )

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -36,7 +36,7 @@
 #include <QHostAddress>
 #include "global.h"
 #include "util.h"
-#include "multicolorledbar.h"
+#include "levelmeter.h"
 
 
 /* Classes ********************************************************************/
@@ -77,7 +77,7 @@ protected:
 
     QWidget*           pLevelsBox;
     QWidget*           pMuteSoloBox;
-    CMultiColorLEDBar* plbrChannelLevel;
+    CLevelMeter*       plbrChannelLevel;
     QSlider*           pFader;
 
     QCheckBox*         pcbMute;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -208,8 +208,8 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     lbrInputLevelL->SetPairedBar ( lbrInputLevelR );
 
     // init input level meter bars
-    lbrInputLevelL->setValue ( 0 );
-    lbrInputLevelR->setValue ( 0 );
+    lbrInputLevelL->Reset();
+    lbrInputLevelR->Reset();
 
     // init status LEDs
     ledBuffers->Reset();
@@ -951,8 +951,8 @@ void CClientDlg::OnTimerSigMet()
     }
 
     // show current level
-    lbrInputLevelL->setValue ( dCurSigLeveldB_L );
-    lbrInputLevelR->setValue ( dCurSigLeveldB_R );
+    lbrInputLevelL->SetValue ( dCurSigLeveldB_L );
+    lbrInputLevelR->SetValue ( dCurSigLeveldB_R );
 }
 
 void CClientDlg::OnTimerBuffersLED()
@@ -1176,8 +1176,8 @@ rbtReverbSelR->setStyleSheet ( "color: rgb(220, 220, 220);"
                                "font:  bold;" );
 #endif
 
-        lbrInputLevelL->SetLevelMeterType ( CMultiColorLEDBar::MT_LED );
-        lbrInputLevelR->SetLevelMeterType ( CMultiColorLEDBar::MT_LED );
+        lbrInputLevelL->SetLevelMeterType ( CLevelMeter::MT_LED );
+        lbrInputLevelR->SetLevelMeterType ( CLevelMeter::MT_LED );
         break;
 
     default:
@@ -1190,8 +1190,8 @@ rbtReverbSelL->setStyleSheet ( "" );
 rbtReverbSelR->setStyleSheet ( "" );
 #endif
 
-        lbrInputLevelL->SetLevelMeterType ( CMultiColorLEDBar::MT_BAR );
-        lbrInputLevelR->SetLevelMeterType ( CMultiColorLEDBar::MT_BAR );
+        lbrInputLevelL->SetLevelMeterType ( CLevelMeter::MT_BAR );
+        lbrInputLevelR->SetLevelMeterType ( CLevelMeter::MT_BAR );
         break;
     }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1083,8 +1083,8 @@ void CClientDlg::Disconnect()
 
     // stop timer for level meter bars and reset them
     TimerSigMet.stop();
-    lbrInputLevelL->setValue ( 0 );
-    lbrInputLevelR->setValue ( 0 );
+    lbrInputLevelL->Reset();
+    lbrInputLevelR->Reset();
 
     // stop other timers
     TimerBuffersLED.stop();

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -203,9 +203,9 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     // init connection button text
     butConnect->setText ( tr ( "C&onnect" ) );
 
-    // pair the input level meter bars together
-    lbrInputLevelR->setPairedBar ( lbrInputLevelL );
-    lbrInputLevelL->setPairedBar ( lbrInputLevelR );
+    // pair the input level meter bars together, for common action
+    lbrInputLevelR->SetPairedBar ( lbrInputLevelL );
+    lbrInputLevelL->SetPairedBar ( lbrInputLevelR );
 
     // init input level meter bars
     lbrInputLevelL->setValue ( 0 );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -78,10 +78,12 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     lbrInputLevelL->setAccessibleName        ( strInpLevHAccText );
     lbrInputLevelL->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelL->setToolTip               ( strInpLevHTT );
+    lbrInputLevelL->setPairedBar             ( lbrInputLevelR );
     lbrInputLevelR->setWhatsThis             ( strInpLevH );
     lbrInputLevelR->setAccessibleName        ( strInpLevHAccText );
     lbrInputLevelR->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelR->setToolTip               ( strInpLevHTT );
+    lbrInputLevelR->setPairedBar             ( lbrInputLevelL );
 
     // connect/disconnect button
     butConnect->setWhatsThis ( "<b>" + tr ( "Connect/Disconnect Button" ) + ":</b> " +

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -78,12 +78,10 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     lbrInputLevelL->setAccessibleName        ( strInpLevHAccText );
     lbrInputLevelL->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelL->setToolTip               ( strInpLevHTT );
-    lbrInputLevelL->setPairedBar             ( lbrInputLevelR );
     lbrInputLevelR->setWhatsThis             ( strInpLevH );
     lbrInputLevelR->setAccessibleName        ( strInpLevHAccText );
     lbrInputLevelR->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelR->setToolTip               ( strInpLevHTT );
-    lbrInputLevelR->setPairedBar             ( lbrInputLevelL );
 
     // connect/disconnect button
     butConnect->setWhatsThis ( "<b>" + tr ( "Connect/Disconnect Button" ) + ":</b> " +
@@ -204,6 +202,10 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
 
     // init connection button text
     butConnect->setText ( tr ( "C&onnect" ) );
+
+    // pair the input level meter bars together
+    lbrInputLevelR->setPairedBar ( lbrInputLevelL );
+    lbrInputLevelL->setPairedBar ( lbrInputLevelR );
 
     // init input level meter bars
     lbrInputLevelL->setValue ( 0 );

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -240,7 +240,7 @@
             <item>
              <layout class="QHBoxLayout">
               <item>
-               <widget class="CMultiColorLEDBar" name="lbrInputLevelL" native="true">
+               <widget class="CLevelMeter" name="lbrInputLevelL" native="true">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
                   <horstretch>0</horstretch>
@@ -256,7 +256,7 @@
                </widget>
               </item>
               <item>
-               <widget class="CMultiColorLEDBar" name="lbrInputLevelR" native="true">
+               <widget class="CLevelMeter" name="lbrInputLevelR" native="true">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
                   <horstretch>0</horstretch>
@@ -574,9 +574,9 @@
    <header>audiomixerboard.h</header>
   </customwidget>
   <customwidget>
-   <class>CMultiColorLEDBar</class>
+   <class>CLevelMeter</class>
    <extends>QWidget</extends>
-   <header>multicolorledbar.h</header>
+   <header>levelmeter.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/levelmeter.cpp
+++ b/src/levelmeter.cpp
@@ -32,8 +32,7 @@
 
 /* Implementation *************************************************************/
 CLevelMeter::CLevelMeter ( QWidget* parent, Qt::WindowFlags f ) :
-    QWidget ( parent, f ),
-    eLevelMeterType ( MT_BAR )
+    QWidget ( parent, f )
 {
     pPairedBar = NULL;
 
@@ -57,8 +56,8 @@ CLevelMeter::CLevelMeter ( QWidget* parent, Qt::WindowFlags f ) :
     // 15px + 2 * 1px + 2 * 1px = 19px
     pwBarMeter->setMinimumSize    ( QSize ( 19, 1 ) );
 
-    // update the meter type (using the default value of the meter type)
-    SetLevelMeterType ( eLevelMeterType );
+    // initialize the meter type to default
+    SetLevelMeterType ( MT_BAR );
 }
 
 CLevelMeter::~CLevelMeter()
@@ -84,8 +83,6 @@ void CLevelMeter::Reset()
 
 void CLevelMeter::SetLevelMeterType ( const ELevelMeterType eNType )
 {
-    eLevelMeterType = eNType;
-
     switch ( eNType )
     {
     case MT_LED:

--- a/src/levelmeter.h
+++ b/src/levelmeter.h
@@ -42,31 +42,42 @@
 
 
 /* Internal classes declaration ***********************************************/
-class CLevelMeterBar
+/* Common interface to LED class and Bar class */
+class CLevelMeterInterface
+{
+public:
+    virtual ~CLevelMeterInterface() {}
+    virtual void SetValue( double dValue ) = 0;
+    virtual void Reset () = 0;
+
+protected:
+    static constexpr float fClipLimitRatio = 0.95f;
+};
+
+class CLevelMeterBar : public CLevelMeterInterface
 {
 public:
 
-    CLevelMeterBar ( QWidget* pParent, float fClipRatio );
+    CLevelMeterBar ( QWidget* pParent );
     virtual ~CLevelMeterBar();
 
-    void SetValue ( double dValue );
-    void Reset();
+    void SetValue ( double dValue ) override;
+    void Reset() override;
 
 protected:
     QProgressBar* pBar;
     QProgressBar* pClipBar;
-    const float   fClipLimitRatio;
 };
 
-class CLevelMeterLED
+class CLevelMeterLED : public CLevelMeterInterface
 {
 public:
 
-    CLevelMeterLED ( QWidget* pParent, float fClipRatio );
+    CLevelMeterLED ( QWidget* pParent );
     virtual ~CLevelMeterLED();
 
-    void SetValue ( int dValue );
-    void Reset();
+    void SetValue( double dValue ) override;
+    void Reset() override;
 
 protected:
     class cLED
@@ -98,11 +109,9 @@ protected:
 
     CVector<cLED*>     vecpLEDs;
     cLED*              pClipLED;
-
-    const float   fClipLimitRatio;
 };
 
-/* Interface class ************************************************************/
+/* Outside interface class ****************************************************/
 class CLevelMeter : public QWidget
 {
     Q_OBJECT
@@ -136,5 +145,6 @@ protected:
     CLevelMeterLED*    pLevelLED;
     CLevelMeter*       pPairedBar;
 
-    static constexpr float fClipLimitRatio = 0.95f;
+    // Common interface to pLevelBar or pLevelLED, depending on selected skin
+    CLevelMeterInterface* pCurrentLevelMeter;
 };

--- a/src/levelmeter.h
+++ b/src/levelmeter.h
@@ -35,51 +35,38 @@
 
 
 /* Definitions ****************************************************************/
-// defines for LED level meter CMultiColorLEDBar
+// defines for LED level meter CLevelMeterLED
 #define NUM_STEPS_LED_BAR                8
 #define RED_BOUND_LED_BAR                7
 #define YELLOW_BOUND_LED_BAR             5
 
 
-/* Classes ********************************************************************/
-
-class CLevelBar
+/* Internal classes declaration ***********************************************/
+class CLevelMeterBar
 {
 public:
 
-    CLevelBar ( QWidget* pParent, float fClipRaio );
-    virtual ~CLevelBar();
+    CLevelMeterBar ( QWidget* pParent, float fClipRatio );
+    virtual ~CLevelMeterBar();
 
-    void setValue ( int dValue );
+    void SetValue ( double dValue );
     void Reset();
 
 protected:
     QProgressBar* pBar;
     QProgressBar* pClipBar;
-    const float fClipLimitRatio;
+    const float   fClipLimitRatio;
 };
 
-class CMultiColorLEDBar : public QWidget
+class CLevelMeterLED
 {
-    Q_OBJECT
-
 public:
-    enum ELevelMeterType
-    {
-        MT_LED,
-        MT_BAR
-    };
 
-    CMultiColorLEDBar ( QWidget* parent = nullptr, Qt::WindowFlags f = nullptr );
-    virtual ~CMultiColorLEDBar();
+    CLevelMeterLED ( QWidget* pParent, float fClipRatio );
+    virtual ~CLevelMeterLED();
 
+    void SetValue ( int dValue );
     void Reset();
-    void setValue ( const double dValue );
-    void SetLevelMeterType ( const ELevelMeterType eNType );
-
-    // Pair another bar with this one. Used to cause action on the paired bar
-    // upon mouse event on this bar.
-    void SetPairedBar ( CMultiColorLEDBar* pBar );
 
 protected:
     class cLED
@@ -109,15 +96,45 @@ protected:
         QLabel*     pLEDLabel;
     };
 
+    CVector<cLED*>     vecpLEDs;
+    cLED*              pClipLED;
+
+    const float   fClipLimitRatio;
+};
+
+/* Interface class ************************************************************/
+class CLevelMeter : public QWidget
+{
+    Q_OBJECT
+
+public:
+    enum ELevelMeterType
+    {
+        MT_LED,
+        MT_BAR
+    };
+
+    CLevelMeter ( QWidget* parent = nullptr, Qt::WindowFlags f = nullptr );
+    virtual ~CLevelMeter();
+
+    void Reset();
+    void SetValue ( const double dValue );
+    void SetLevelMeterType ( const ELevelMeterType eNType );
+
+    // Pair another bar with this one. Used to cause action on the paired bar
+    // upon mouse event on this bar.
+    void SetPairedBar ( CLevelMeter* pBar );
+
+protected:
+
     virtual void changeEvent ( QEvent* curEvent );
     void mousePressEvent ( QMouseEvent* event ) override;
 
     QStackedLayout*    pStackedLayout;
     ELevelMeterType    eLevelMeterType;
-    CVector<cLED*>     vecpLEDs;
-    cLED*              pClipLED;
-    CLevelBar*         pLevelBar;
-    CMultiColorLEDBar* pPairedBar;
+    CLevelMeterBar*    pLevelBar;
+    CLevelMeterLED*    pLevelLED;
+    CLevelMeter*       pPairedBar;
 
     static constexpr float fClipLimitRatio = 0.95f;
 };

--- a/src/levelmeter.h
+++ b/src/levelmeter.h
@@ -42,16 +42,14 @@
 
 
 /* Internal classes declaration ***********************************************/
-/* Common interface to LED class and Bar class */
+/* Common private interface to LED class and Bar class */
 class CLevelMeterInterface
 {
 public:
     virtual ~CLevelMeterInterface() {}
-    virtual void SetValue( double dValue ) = 0;
+    virtual void SetValue ( double dValue ) = 0;
     virtual void Reset () = 0;
-
-protected:
-    static constexpr float fClipLimitRatio = 0.95f;
+    virtual void ClipSet( bool bSet ) = 0;
 };
 
 class CLevelMeterBar : public CLevelMeterInterface
@@ -63,6 +61,7 @@ public:
 
     void SetValue ( double dValue ) override;
     void Reset() override;
+    void ClipSet( bool bSet ) override;
 
 protected:
     QProgressBar* pBar;
@@ -78,6 +77,7 @@ public:
 
     void SetValue( double dValue ) override;
     void Reset() override;
+    void ClipSet( bool bSet ) override;
 
 protected:
     class cLED
@@ -129,13 +129,16 @@ public:
     void Reset();
     void SetValue ( const double dValue );
     void SetLevelMeterType ( const ELevelMeterType eNType );
+    void SetClipTimeout ( int iMilliseconds );
 
     // Pair another bar with this one. Used to cause action on the paired bar
     // upon mouse event on this bar.
     void SetPairedBar ( CLevelMeter* pBar );
 
-protected:
+protected slots:
+    void ClipReset();
 
+protected:
     virtual void changeEvent ( QEvent* curEvent );
     void mousePressEvent ( QMouseEvent* event ) override;
 
@@ -146,4 +149,8 @@ protected:
 
     // Common interface to pLevelBar or pLevelLED, depending on selected skin
     CLevelMeterInterface* pCurrentLevelMeter;
+
+    QTimer*            pClipTimer;
+
+    static constexpr float fClipLimitRatio = 0.95f;
 };

--- a/src/levelmeter.h
+++ b/src/levelmeter.h
@@ -140,7 +140,6 @@ protected:
     void mousePressEvent ( QMouseEvent* event ) override;
 
     QStackedLayout*    pStackedLayout;
-    ELevelMeterType    eLevelMeterType;
     CLevelMeterBar*    pLevelBar;
     CLevelMeterLED*    pLevelLED;
     CLevelMeter*       pPairedBar;

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -50,6 +50,8 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f ) :
     // create LEDs
     vecpLEDs.Init ( NUM_STEPS_LED_BAR );
 
+    pPairedBar = NULL;
+
     for ( int iLEDIdx = NUM_STEPS_LED_BAR - 1; iLEDIdx >= 0; iLEDIdx-- )
     {
         // create LED object
@@ -191,10 +193,20 @@ void CMultiColorLEDBar::mousePressEvent ( QMouseEvent* event )
 {
     if ( event->button() == Qt::LeftButton )
     {
-        pClipLED->setColor ( cLED::ELightColor::RL_GREY );
+        // Mainly to reset the clip LED, but might be useful to reset the whole
+        // color LED bar.
+        Reset ( isEnabled() );
+        if (pPairedBar != NULL )
+        {
+            pPairedBar->Reset ( pPairedBar->isEnabled() );
+        }
     }
 }
 
+void CMultiColorLEDBar::setPairedBar ( CMultiColorLEDBar* pBar )
+{
+    this->pPairedBar = pBar;
+}
 
 CMultiColorLEDBar::cLED::cLED ( QWidget* parent ) :
     BitmCubeRoundDisabled ( QString::fromUtf8 ( ":/png/LEDs/res/CLEDDisabledSmall.png" ) ),

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -25,6 +25,8 @@
  *
 \******************************************************************************/
 
+#include <QMouseEvent>
+
 #include "multicolorledbar.h"
 
 
@@ -42,7 +44,7 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f ) :
 
     // create clip LED
     pClipLED = new cLED ( parent );
-    pLEDLayout->addWidget (pClipLED->getLabelPointer() );
+    pLEDLayout->addWidget ( pClipLED->getLabelPointer() );
     pLEDLayout->addStretch(); // Keep clip LED separated from the rest of the LED bar
 
     // create LEDs
@@ -116,6 +118,7 @@ void CMultiColorLEDBar::Reset ( const bool bEnabled )
             vecpLEDs[iLEDIdx]->setColor ( cLED::RL_DISABLED );
         }
     }
+    pClipLED->setColor ( cLED::RL_GREY );
 }
 
 void CMultiColorLEDBar::SetLevelMeterType ( const ELevelMeterType eNType )
@@ -164,6 +167,8 @@ void CMultiColorLEDBar::setValue ( const double dValue )
                         {
                             // red region
                             vecpLEDs[iLEDIdx]->setColor ( cLED::RL_RED );
+                            // indicate clipping signal until user click
+                            pClipLED->setColor ( cLED::RL_RED );
                         }
                     }
                 }
@@ -181,6 +186,15 @@ void CMultiColorLEDBar::setValue ( const double dValue )
         }
     }
 }
+
+void CMultiColorLEDBar::mousePressEvent ( QMouseEvent* event )
+{
+    if ( event->button() == Qt::LeftButton )
+    {
+        pClipLED->setColor ( cLED::ELightColor::RL_GREY );
+    }
+}
+
 
 CMultiColorLEDBar::cLED::cLED ( QWidget* parent ) :
     BitmCubeRoundDisabled ( QString::fromUtf8 ( ":/png/LEDs/res/CLEDDisabledSmall.png" ) ),

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -209,7 +209,7 @@ void CMultiColorLEDBar::mousePressEvent ( QMouseEvent* event )
     }
 }
 
-void CMultiColorLEDBar::setPairedBar ( CMultiColorLEDBar* pBar )
+void CMultiColorLEDBar::SetPairedBar ( CMultiColorLEDBar* pBar )
 {
     this->pPairedBar = pBar;
 }
@@ -307,6 +307,7 @@ CLevelBar::CLevelBar ( QWidget* pParent, float fClipRatio ):
 CLevelBar::~CLevelBar()
 {
     delete pClipBar;
+    delete pBar;
 }
 
 void CLevelBar::setValue ( int dValue )

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -45,7 +45,7 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f ) :
     // create clip LED
     pClipLED = new cLED ( parent );
     pLEDLayout->addWidget ( pClipLED->getLabelPointer() );
-    pLEDLayout->addStretch(); // Keep clip LED separated from the rest of the LED bar
+    pLEDLayout->addStretch(2); // Keep clip LED separated from the rest of the LED bar
 
     // create LEDs
     vecpLEDs.Init ( NUM_STEPS_LED_BAR );
@@ -56,8 +56,13 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f ) :
     {
         // create LED object
         vecpLEDs[iLEDIdx] = new cLED ( parent );
-        pLEDLayout->addStretch();
+
+        // add LED to layout with spacer (do not add spacer after last LED)
         pLEDLayout->addWidget ( vecpLEDs[iLEDIdx]->getLabelPointer() );
+        if ( iLEDIdx > 0 )
+        {
+            pLEDLayout->addStretch(1);
+        }
     }
 
     // initialize bar meter
@@ -93,6 +98,9 @@ CMultiColorLEDBar::~CMultiColorLEDBar()
     {
         delete vecpLEDs[iLEDIdx];
     }
+    delete pClipLED;
+    delete pProgressBar;
+    delete pStackedLayout;
 }
 
 void CMultiColorLEDBar::changeEvent ( QEvent* curEvent )

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -101,11 +101,11 @@ void CMultiColorLEDBar::changeEvent ( QEvent* curEvent )
     if ( curEvent->type() == QEvent::EnabledChange )
     {
         // reset all LEDs
-        Reset ( this->isEnabled() );
+        Reset();
     }
 }
 
-void CMultiColorLEDBar::Reset ( const bool bEnabled )
+void CMultiColorLEDBar::Reset()
 {
     if ( eLevelMeterType == MT_LED )
     {
@@ -113,7 +113,7 @@ void CMultiColorLEDBar::Reset ( const bool bEnabled )
         for ( int iLEDIdx = 0; iLEDIdx < NUM_STEPS_LED_BAR; iLEDIdx++ )
         {
             // different reset behavior for enabled and disabled control
-            if ( bEnabled )
+            if ( this->isEnabled() )
             {
                 vecpLEDs[iLEDIdx]->setColor ( cLED::RL_GREY );
             }
@@ -201,10 +201,10 @@ void CMultiColorLEDBar::mousePressEvent ( QMouseEvent* event )
     {
         // Mainly to reset the clip LED, but might be useful to reset the whole
         // color LED bar.
-        Reset ( isEnabled() );
+        Reset();
         if (pPairedBar != NULL )
         {
-            pPairedBar->Reset ( pPairedBar->isEnabled() );
+            pPairedBar->Reset();
         }
     }
 }

--- a/src/multicolorledbar.cpp
+++ b/src/multicolorledbar.cpp
@@ -40,6 +40,11 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f ) :
     pLEDLayout->setMargin    ( 0 );
     pLEDLayout->setSpacing   ( 0 );
 
+    // create clip LED
+    pClipLED = new cLED ( parent );
+    pLEDLayout->addWidget (pClipLED->getLabelPointer() );
+    pLEDLayout->addStretch(); // Keep clip LED separated from the rest of the LED bar
+
     // create LEDs
     vecpLEDs.Init ( NUM_STEPS_LED_BAR );
 
@@ -47,13 +52,7 @@ CMultiColorLEDBar::CMultiColorLEDBar ( QWidget* parent, Qt::WindowFlags f ) :
     {
         // create LED object
         vecpLEDs[iLEDIdx] = new cLED ( parent );
-
-        // add LED to layout with spacer (do not add spacer on the bottom of the first LED)
-        if ( iLEDIdx < NUM_STEPS_LED_BAR - 1 )
-        {
-            pLEDLayout->addStretch();
-        }
-
+        pLEDLayout->addStretch();
         pLEDLayout->addWidget ( vecpLEDs[iLEDIdx]->getLabelPointer() );
     }
 

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -42,6 +42,23 @@
 
 
 /* Classes ********************************************************************/
+
+class CLevelBar
+{
+public:
+
+    CLevelBar ( QWidget* pParent, float fClipRaio );
+    virtual ~CLevelBar();
+
+    void setValue ( int dValue );
+    void Reset();
+
+protected:
+    QProgressBar* pBar;
+    QProgressBar* pClipBar;
+    const float fClipLimitRatio;
+};
+
 class CMultiColorLEDBar : public QWidget
 {
     Q_OBJECT
@@ -96,6 +113,8 @@ protected:
     ELevelMeterType    eLevelMeterType;
     CVector<cLED*>     vecpLEDs;
     cLED*              pClipLED;
-    QProgressBar*      pProgressBar;
+    CLevelBar*         pLevelBar;
     CMultiColorLEDBar* pPairedBar;
+
+    static constexpr float fClipLimitRatio = 0.95f;
 };

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -73,10 +73,13 @@ public:
     CMultiColorLEDBar ( QWidget* parent = nullptr, Qt::WindowFlags f = nullptr );
     virtual ~CMultiColorLEDBar();
 
+    void Reset();
     void setValue ( const double dValue );
     void SetLevelMeterType ( const ELevelMeterType eNType );
-    void setPairedBar ( CMultiColorLEDBar* pBar );
-    void Reset();
+
+    // Pair another bar with this one. Used to cause action on the paired bar
+    // upon mouse event on this bar.
+    void SetPairedBar ( CMultiColorLEDBar* pBar );
 
 protected:
     class cLED
@@ -105,8 +108,6 @@ protected:
         ELightColor eCurLightColor;
         QLabel*     pLEDLabel;
     };
-
-    void Reset ( const bool bEnabled );
 
     virtual void changeEvent ( QEvent* curEvent );
     void mousePressEvent ( QMouseEvent* event ) override;

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -76,6 +76,7 @@ public:
     void setValue ( const double dValue );
     void SetLevelMeterType ( const ELevelMeterType eNType );
     void setPairedBar ( CMultiColorLEDBar* pBar );
+    void Reset();
 
 protected:
     class cLED
@@ -106,6 +107,7 @@ protected:
     };
 
     void Reset ( const bool bEnabled );
+
     virtual void changeEvent ( QEvent* curEvent );
     void mousePressEvent ( QMouseEvent* event ) override;
 

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -58,6 +58,7 @@ public:
 
     void setValue ( const double dValue );
     void SetLevelMeterType ( const ELevelMeterType eNType );
+    void setPairedBar ( CMultiColorLEDBar* pBar );
 
 protected:
     class cLED
@@ -91,9 +92,10 @@ protected:
     virtual void changeEvent ( QEvent* curEvent );
     void mousePressEvent ( QMouseEvent* event ) override;
 
-    QStackedLayout* pStackedLayout;
-    ELevelMeterType eLevelMeterType;
-    CVector<cLED*>  vecpLEDs;
-    cLED*           pClipLED;
-    QProgressBar*   pProgressBar;
+    QStackedLayout*    pStackedLayout;
+    ELevelMeterType    eLevelMeterType;
+    CVector<cLED*>     vecpLEDs;
+    cLED*              pClipLED;
+    QProgressBar*      pProgressBar;
+    CMultiColorLEDBar* pPairedBar;
 };

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -93,5 +93,6 @@ protected:
     QStackedLayout* pStackedLayout;
     ELevelMeterType eLevelMeterType;
     CVector<cLED*>  vecpLEDs;
+    cLED*           pClipLED;
     QProgressBar*   pProgressBar;
 };

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -89,6 +89,7 @@ protected:
 
     void Reset ( const bool bEnabled );
     virtual void changeEvent ( QEvent* curEvent );
+    void mousePressEvent ( QMouseEvent* event ) override;
 
     QStackedLayout* pStackedLayout;
     ELevelMeterType eLevelMeterType;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -299,7 +299,7 @@ CONNECTION LESS MESSAGES
     n is number of connected clients
 
     the values are the maximum channel levels for a client frame converted
-    to the range of CMultiColorLEDBar in 4 bits, two entries per byte
+    to the range of CLevelMeter in 4 bits, two entries per byte
     with the earlier channel in the lower half of the byte
 
     where an odd number of clients is connected, there will be four unused

--- a/src/server.h
+++ b/src/server.h
@@ -42,7 +42,7 @@
 #include "util.h"
 #include "serverlogging.h"
 #include "serverlist.h"
-#include "multicolorledbar.h"
+#include "levelmeter.h"
 #include "recorder/jamrecorder.h"
 
 


### PR DESCRIPTION
This PR adds a clipping signal indication above the level meters, in form of a LED or a red rectangle depending on skin.

The user may reset the indication by clicking anywhere on the meter/clipping LED.
Stereo meters reset both indications on clicking on any of the two meters.

Not implemented, would be nice to have:
- resetting clipping indication on input meter resets the user's clipping indication in the audio mixer
- resetting clipping indication on input meter resets the user's clipping indication in the audio mixer *of all clients*
- make showing clipping indication in the audio mixer an opt-in
