### PR TITLE
debian/watch: Adapt to the tags on github

### DIFF
--- a/distributions/debian/watch
+++ b/distributions/debian/watch
@@ -1,5 +1,5 @@
 version=4
 # GitHub hosted projects
-opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%@PACKAGE@-$1.tar.gz%" \
+opts=uversionmangle=s%_%.%g,filenamemangle=s%(?:.*?)?(r\d[\d_]*)\.tar\.gz%@PACKAGE@-$1.tar.gz% \
    https://github.com/corrados/jamulus/tags \
-   (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate
+   (?:.*?/)?r(\d[\d_]*)\.tar\.gz debian uupdate


### PR DESCRIPTION
It will download the upstream package as e.g.
jamulus-r3_5_3.tar.gz (respecting upstream versioning)
and link as jamulus_3.5.3.orig.tar.gz

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>