### PR TITLE
Feature/show channel numbers

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -148,9 +148,9 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     plblCountryFlag->setWhatsThis ( strFaderText );
     plblCountryFlag->setAccessibleName ( tr ( "Mixer channel country flag" ) );
 
-    QString strChannelNumberText = tr ( "<b>Channel Number:</b> "
-        "Control this channel by sending MIDI CC messages with control "
-        "number 70+channelNumber." );
+    QString strChannelNumberText = "<b>" + tr ( "Channel Number" ) + ":</b> " +
+         tr ("Control this channel by sending MIDI CC messages with control "
+             "number 70+channelNumber." );
 
     plblChannelNumber->setWhatsThis ( strChannelNumberText );
     plblChannelNumber->setAccessibleName (
@@ -528,7 +528,7 @@ void CChannelFader::SetChannelInfos ( const CChannelInfo& cChanInfo )
     plblCountryFlag->setToolTip   ( strToolTip );
     plblInstrument->setToolTip    ( strToolTip );
     plblLabel->setToolTip         ( strToolTip );
-    plblChannelNumber->setToolTip ( "Channel Number" );
+    plblChannelNumber->setToolTip ( tr ("Channel Number") );
 }
 
 double CChannelFader::CalcFaderGain ( const int value )

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -49,6 +49,8 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     plblInstrument              = new QLabel            ( pFrame );
     plblCountryFlag             = new QLabel            ( pFrame );
 
+    plblChannelNumber           = new QLabel            ( "" );
+
     QVBoxLayout* pMainGrid      = new QVBoxLayout       ( pFrame );
     QHBoxLayout* pLevelsGrid    = new QHBoxLayout       ( pLevelsBox );
     QVBoxLayout* pMuteSoloGrid  = new QVBoxLayout       ( pMuteSoloBox );
@@ -99,6 +101,8 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     pMainGrid->addWidget ( pLevelsBox,   0, Qt::AlignHCenter );
     pMainGrid->addWidget ( pMuteSoloBox, 0, Qt::AlignHCenter );
     pMainGrid->addWidget ( pLabelInstBox );
+
+    pMainGrid->addWidget ( plblChannelNumber, 0, Qt::AlignHCenter );
 
     // add fader frame to audio mixer board layout
     pParentLayout->addWidget( pFrame );

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -74,6 +74,13 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
         "QLabel { color: black;"
         "         font:  bold; }" );
 
+    plblChannelNumber->setTextFormat    ( Qt::PlainText );
+    plblChannelNumber->setAlignment     ( Qt::AlignHCenter | Qt::AlignVCenter );
+    plblChannelNumber->setMinimumHeight ( 30 );
+    plblChannelNumber->setStyleSheet (
+        "QLabel { color: white;"
+        "         font:  bold; }" );
+
     // set margins of the layouts to zero to get maximum space for the controls
     pMainGrid->setContentsMargins ( 0, 0, 0, 0 );
 
@@ -144,6 +151,13 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     plblCountryFlag->setWhatsThis ( strFaderText );
     plblCountryFlag->setAccessibleName ( tr ( "Mixer channel country flag" ) );
 
+    QString strChannelNumberText = tr ( "<b>Channel Number:</b> "
+        "Control this channel by sending MIDI CC messages with control "
+        "number 70+channelNumber." );
+
+    plblChannelNumber->setWhatsThis ( strChannelNumberText );
+    plblChannelNumber->setAccessibleName (
+        tr ( "Channel Number for MIDI control" ) );
 
     // Connections -------------------------------------------------------------
     QObject::connect ( pFader, SIGNAL ( valueChanged ( int ) ),
@@ -264,12 +278,14 @@ void CChannelFader::Reset()
     plblCountryFlag->setToolTip ( "" );
     strReceivedName = "";
     SetupFaderTag ( SL_NOT_SET );
+    plblChannelNumber->setText( "" );
 
     // set a defined tool tip time out
     const int iToolTipDurMs = 30000;
     plblLabel->setToolTipDuration       ( iToolTipDurMs );
     plblInstrument->setToolTipDuration  ( iToolTipDurMs );
     plblCountryFlag->setToolTipDuration ( iToolTipDurMs );
+    plblChannelNumber->setToolTipDuration ( iToolTipDurMs );
 
     bOtherChannelIsSolo = false;
 }
@@ -370,6 +386,12 @@ void CChannelFader::SetText ( const CChannelInfo& ChanInfo )
 
     plblLabel->setText ( strModText );
 }
+
+void CChannelFader::SetChannelNumber ( int channel )
+{
+    plblChannelNumber->setText ( QString::number(channel) );
+}
+
 
 void CChannelFader::SetChannelInfos ( const CChannelInfo& cChanInfo )
 {
@@ -499,9 +521,10 @@ void CChannelFader::SetChannelInfos ( const CChannelInfo& cChanInfo )
         strToolTip.prepend ( "<h3>" + tr ( "Musician Profile" ) + "</h3>" );
     }
 
-    plblCountryFlag->setToolTip ( strToolTip );
-    plblInstrument->setToolTip  ( strToolTip );
-    plblLabel->setToolTip       ( strToolTip );
+    plblCountryFlag->setToolTip   ( strToolTip );
+    plblInstrument->setToolTip    ( strToolTip );
+    plblLabel->setToolTip         ( strToolTip );
+    plblChannelNumber->setToolTip ( "Channel Number" );
 }
 
 double CChannelFader::CalcFaderGain ( const int value )

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -572,6 +572,7 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent, Qt::WindowFlags ) :
     {
         vecpChanFader[i] = new CChannelFader ( this, pMainLayout );
         vecpChanFader[i]->Hide();
+        vecpChanFader[i]->SetChannelNumber(i);
     }
 
     // insert horizontal spacer
@@ -704,6 +705,7 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
                 {
                     // the fader was not in use, reset everything for new client
                     vecpChanFader[i]->Reset();
+                    vecpChanFader[i]->SetChannelNumber(i);
 
                     // show fader
                     vecpChanFader[i]->Show();

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -77,9 +77,6 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     plblChannelNumber->setTextFormat    ( Qt::PlainText );
     plblChannelNumber->setAlignment     ( Qt::AlignHCenter | Qt::AlignVCenter );
     plblChannelNumber->setMinimumHeight ( 30 );
-    plblChannelNumber->setStyleSheet (
-        "QLabel { color: white;"
-        "         font:  bold; }" );
 
     // set margins of the layouts to zero to get maximum space for the controls
     pMainGrid->setContentsMargins ( 0, 0, 0, 0 );
@@ -193,6 +190,10 @@ void CChannelFader::SetGUIDesign ( const EGUIDesign eNewDesign )
         pcbMute->setText                    ( tr ( "MUTE" ) );
         pcbSolo->setText                    ( tr ( "SOLO" ) );
         plbrChannelLevel->SetLevelMeterType ( CMultiColorLEDBar::MT_LED );
+        plblChannelNumber->setStyleSheet (
+            "QLabel { color: white;"
+            "         font:  bold; }" );
+
         break;
 
     default:
@@ -201,6 +202,9 @@ void CChannelFader::SetGUIDesign ( const EGUIDesign eNewDesign )
         pcbMute->setText                    ( tr ( "Mute" ) );
         pcbSolo->setText                    ( tr ( "Solo" ) );
         plbrChannelLevel->SetLevelMeterType ( CMultiColorLEDBar::MT_BAR );
+        plblChannelNumber->setStyleSheet (
+            "QLabel { color: black;"
+            "         font:  bold; }" );
         break;
     }
 }

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -48,6 +48,7 @@ public:
     CChannelFader ( QWidget* pNW, QHBoxLayout* pParentLayout );
 
     void SetText ( const CChannelInfo& ChanInfo );
+    void SetChannelNumber ( int channel );
     QString GetReceivedName() { return strReceivedName; }
     void SetChannelInfos ( const CChannelInfo& cChanInfo );
     void Show() { pFrame->show(); }

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -88,6 +88,8 @@ protected:
     QLabel*            plblInstrument;
     QLabel*            plblCountryFlag;
 
+    QLabel*            plblChannelNumber;
+
     QString            strReceivedName;
 
     bool               bOtherChannelIsSolo;


### PR DESCRIPTION
When controlling the mixer strip levels via MIDI, the channel number of the strip must be known. But when people leave the jamulus server, their channel numbers become unused and are reused for people join thereafter. Thus, the channel number for each strip is not obvious to the user.

I added a visible channel number to the mixer. This eases the use of a MIDI controller.

I kindly ask you to pull my change. However, if you are not satisfied, please let me know. I will try to update my code accordingly.