### PR TITLE
update debian packaging

### DIFF
--- a/distributions/debian/control
+++ b/distributions/debian/control
@@ -23,9 +23,6 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  adduser,
- jackd,
- qt5-default,
- qtchooser,
 Description: Low latency Audio Server/Client
  The Jamulus software enables musicians to perform real-time jam sessions over
  the internet. There is one server running the Jamulus server software which


### PR DESCRIPTION
jackd will be automatically added
The 2 others are pulling over 40 -dev uneeded packages for the users.