### PR TITLE
Initial HealthCheck Code

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -194,6 +194,7 @@ HEADERS += src/audiomixerboard.h \
     src/connectdlg.h \
     src/global.h \
     src/clientdlg.h \
+    src/healthcheck.h \
     src/serverdlg.h \
     src/multicolorled.h \
     src/multicolorledbar.h \
@@ -203,6 +204,7 @@ HEADERS += src/audiomixerboard.h \
     src/serverlogging.h \
     src/settings.h \
     src/socket.h \
+    src/socketerrors.h \
     src/soundbase.h \
     src/testbench.h \
     src/util.h \
@@ -315,6 +317,7 @@ SOURCES += src/audiomixerboard.cpp \
     src/clientsettingsdlg.cpp \
     src/connectdlg.cpp \
     src/clientdlg.cpp \
+    src/healthcheck.cpp \
     src/serverdlg.cpp \
     src/main.cpp \
     src/multicolorled.cpp \
@@ -325,6 +328,7 @@ SOURCES += src/audiomixerboard.cpp \
     src/serverlogging.cpp \
     src/settings.cpp \
     src/socket.cpp \
+    src/socketerrors.cpp \
     src/soundbase.cpp \
     src/util.cpp \
     src/analyzerconsole.cpp \

--- a/src/global.h
+++ b/src/global.h
@@ -179,6 +179,9 @@ LED bar:      lbr
 #endif
 #define MAX_NUM_CHANNELS                 50 // max number channels for server
 
+// Maximum number of HealthCheck connections allowed
+#define MAX_NUM_HEALTH_CONNECTIONS       25
+
 // actual number of used channels in the server
 // this parameter can safely be changed from 1 to MAX_NUM_CHANNELS
 // without any other changes in the code

--- a/src/healthcheck.cpp
+++ b/src/healthcheck.cpp
@@ -1,0 +1,192 @@
+/******************************************************************************\
+ * Copyright (c) 2004-2020
+ *
+ * Author(s):
+ *  Aron Vietti
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+\******************************************************************************/
+
+#include "healthcheck.h"
+#include "socket.h"
+#include "socketerrors.h"
+#include <string>
+#include <fcntl.h>
+#include "global.h"
+#include <QString>
+#include <QTextStream>
+#include "util.h"
+
+using namespace SocketError;
+
+/* Classes *******************************************************************/
+
+CHealthCheckSocket::CHealthCheckSocket(const quint16 iPortNumber)
+    : bListening(false)
+{
+    Init(iPortNumber);
+}
+
+CHealthCheckSocket::~CHealthCheckSocket()
+{
+    Close();
+}
+
+void CHealthCheckSocket::Init(const quint16 iPortNumber)
+{
+#ifdef _WIN32
+    // for the Windows socket usage we have to start it up first
+
+// TODO check for error and exit application on error
+
+    WSADATA wsa;
+    WSAStartup(MAKEWORD(1, 0), &wsa);
+#endif
+
+    TcpSocket = socket(AF_INET, SOCK_STREAM, 0);
+
+    if(!SetNonBlocking(TcpSocket))
+    {
+        HandleSocketError(GetError());
+        return;
+    }
+
+    sockaddr_in TcpSocketInAddr;
+
+    TcpSocketInAddr.sin_family = AF_INET;
+    TcpSocketInAddr.sin_addr.s_addr = INADDR_ANY;
+    TcpSocketInAddr.sin_port = htons(iPortNumber);
+
+    if (!BindSocket(TcpSocket, TcpSocketInAddr))
+        HandleSocketError(GetError());
+}
+
+#ifdef _WIN32
+    const SOCKET &CHealthCheckSocket::Socket()
+#else
+    const int &CHealthCheckSocket::Socket()
+#endif
+{
+    return TcpSocket;
+}
+
+void CHealthCheckSocket::Listen()
+{
+    int listening = listen(TcpSocket, 0);
+
+    if (listening == -1)
+    {
+        HandleSocketError(GetError());
+        return;
+    }
+
+    bListening = true;
+}
+
+#ifdef _WIN32
+SOCKET CHealthCheckSocket::Accept()
+{
+    int addrlen;
+#else
+int CHealthCheckSocket::Accept()
+{
+    socklen_t addrlen;
+#endif
+    sockaddr addr;
+
+    return accept(TcpSocket, &addr, &addrlen);
+}
+
+void CHealthCheckSocket::Close()
+{
+#ifdef _WIN32
+    // closesocket will cause recvfrom to return with an error because the
+    // socket is closed -> then the thread can safely be shut down
+    closesocket(TcpSocket);
+#elif defined ( __APPLE__ ) || defined ( __MACOSX )
+    // on Mac the general close has the same effect as closesocket on Windows
+    close(TcpSocket);
+#else
+    // on Linux the shutdown call cancels the recvfrom
+    shutdown(TcpSocket, SHUT_RDWR);
+#endif
+
+    bListening = false;
+}
+
+void CHealthCheckSocket::HandleConnections()
+{
+    if(!bListening) return;
+
+#ifdef _WIN32
+        SOCKET newConnection = Accept();
+#else
+	    int newConnection  = Accept();
+#endif
+        
+#ifdef _WIN32
+        if (newConnection == INVALID_SOCKET)
+        {
+#else
+        if (newConnection == -1)
+        {
+#endif
+            int error = GetError();
+
+            if (!IsNonBlockingError(error))
+            {
+                Close();
+                HandleSocketError(error);
+                return;
+            }
+        }
+	    else
+	    {
+            bool nonblocking = SetNonBlocking(newConnection);
+
+            if(!nonblocking)
+                HandleSocketError(GetError());
+
+            vecConnectionSockets.push_back(newConnection);
+	    }
+        
+        // Check existing connections. If they're closed then remove them
+        for (auto connection = vecConnectionSockets.cbegin(); connection != vecConnectionSockets.cend();)
+        {  
+            if (!SocketConnected(*connection))
+            {
+                CloseSocket(*connection);
+                connection = vecConnectionSockets.erase(connection);
+            }
+            else
+                ++connection;
+        }
+
+        // Make sure we don't have too many connections.
+        //Disconnect and remove the oldest one if we do.
+        if (vecConnectionSockets.size() > MAX_NUM_HEALTH_CONNECTIONS)
+        {
+#ifdef _WIN32
+            SOCKET& oldConnection = vecConnectionSockets.front();
+#else
+            int& oldConnection = vecConnectionSockets.front();
+#endif
+            vecConnectionSockets.erase(vecConnectionSockets.cbegin());
+            CloseSocket(oldConnection);
+        }
+}

--- a/src/healthcheck.h
+++ b/src/healthcheck.h
@@ -1,0 +1,90 @@
+/******************************************************************************\
+ * Copyright (c) 2004-2020
+ *
+ * Author(s):
+ *  Aron Vietti
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Health Check
+ * This is currently just a TCP socket on the same port as the main Socket
+ * That accepts conncetions for the express puprpose of checking if the
+ * process is healthy. This helps in cloud environments, like AWS,
+ * for load balanaciing.
+\******************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QtGlobal>
+#include "util.h"
+#ifndef _WIN32
+# include <netinet/in.h>
+# include <sys/socket.h>
+#else
+# include <winsock2.h>
+#endif
+
+// TCP Socket whose only purpose is to let Health Check monitoring software connect
+// to the service to verify it is still functioning.
+class CHealthCheckSocket : public QObject
+{
+    Q_OBJECT
+
+public:
+    CHealthCheckSocket(const quint16 iPortNumber);
+
+    virtual ~CHealthCheckSocket();
+
+    // Start listening for incoming conncetions
+    void Listen();
+
+    // Close the Socket and all of it's Connections
+    void Close();
+
+    void HandleConnections();
+
+    void Init(const quint16 iPortNumber);
+
+#ifdef _WIN32
+    const SOCKET &Socket();
+#else
+    const int &Socket();
+#endif
+
+private:
+    bool bListening;
+
+    // Accept a connection from the socket
+#ifdef _WIN32
+    SOCKET Accept();
+#else
+    int Accept();
+#endif
+
+#ifdef _WIN32
+    SOCKET TcpSocket;
+#else
+    int TcpSocket;
+#endif
+
+#ifdef _WIN32
+    CVector<SOCKET> vecConnectionSockets;
+#else
+    CVector<int> vecConnectionSockets;
+#endif
+};

--- a/src/socketerrors.cpp
+++ b/src/socketerrors.cpp
@@ -1,0 +1,164 @@
+/******************************************************************************\
+ * Copyright (c) 2004-2020
+ *
+ * Author(s):
+ *  Aron Vietti
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Health Check
+ * This is currently just a TCP socket on the same port as the main Socket
+ * That accepts conncetions for the express puprpose of checking if the
+ * process is healthy. This helps in cloud environments, like AWS,
+ * for load balanaciing.
+\******************************************************************************/
+
+#include "socketerrors.h"
+#include "global.h"
+
+#ifndef _WIN32
+# include <netinet/in.h>
+# include <sys/socket.h>
+#else
+# include <winsock2.h>
+#endif
+
+// Handle Socket Errors for Posix and Windows
+void SocketError::HandleSocketError(int error)
+{
+    switch (error)
+    {
+#ifdef _WIN32
+    case WSANOTINITIALISED:
+        throw CGenErr("HealthCheck: A successful WSAStartup call must occur before using this function.", "Network Error");
+
+#endif
+#ifndef _WIN32
+    case EACCES:
+#endif
+        throw CGenErr("HealthCheck: The address is protected, and the user is not the superuser.", "Network Error");
+
+#ifndef _WIN32
+    case EADDRINUSE:
+#else
+    case WSAEADDRINUSE:
+    case WSAEISCONN:
+#endif
+        throw CGenErr("HealthCheck: The given address is already in use.", "Network Error");
+
+
+#ifndef _WIN32
+    case EBADF:
+#else
+    case WSAENOTCONN:
+    case WSAENETRESET:
+    case WSAESHUTDOWN:
+#endif
+        throw CGenErr("HealthCheck: not a valid file descriptor or is not open for reading.", "Network Error");
+
+#ifndef _WIN32
+    case EINVAL:
+#else
+    case WSAEINVAL:
+#endif
+        throw CGenErr("HealthCheck: The socket is already bound to an address, or addrlen is wrong, \
+            or addr is not a valid address for this socket's domain. ", "Network Error");
+
+#ifndef _WIN32
+    case ENOTSOCK:
+#else
+    case WSAENOTSOCK:
+#endif
+        throw CGenErr("HealthCheck: The file descriptor sockfd does not refer to a socket.", "Network Error");
+
+#ifndef _WIN32
+    case EOPNOTSUPP:
+#else
+    case WSAEOPNOTSUPP:
+#endif
+        throw CGenErr("HealthCheck: The socket is not of a type that supports the listen() operation.", "Network Error");
+
+#ifndef _WIN32
+    case EFAULT:
+#else
+    case WSAEFAULT:
+#endif
+        throw CGenErr("HealthCheck: buf is outside your accessible address space.", "Network Error");
+
+#ifndef _WIN32
+    case EINTR:
+#else
+#endif
+        throw CGenErr("HealthCheck: The call was interrupted by a signal before any data was read.", "Network Error");
+
+#ifndef _WIN32
+    case EIO:
+#else
+#endif
+        throw CGenErr("HealthCheck: I/O error.  This will happen for example when the process is \
+            in a background process group, tries to read from its \
+            controlling terminal, and either it is ignoring or blocking \
+            SIGTTIN or its process group is orphaned.It may also occur \
+            when there is a low - level I / O error while reading from a disk \
+            or tape.A further possible cause of EIO on networked \
+            filesystems is when an advisory lock had been taken out on the \
+            file descriptor and this lock has been lost.See the Lost \
+            locks section of fcntl(2) for further details.", "Network Error");
+
+#ifdef _WIN32
+    case WSAENOBUFS:
+        throw CGenErr("HealthCheck: No buffer space is available.", "Network Error");
+
+    case WSAEMFILE:
+        throw CGenErr("HealthCheck: No more socket descriptors are available.", "Network Error");
+
+    case WSAENETDOWN:
+        throw CGenErr("HealthCheck: The network subsystem has failed.", "Network Error");
+
+#endif
+    default:
+        QString e = std::string("HealthCheck: Socket error # " + std::to_string(error)).c_str();
+        throw CGenErr(e, "Network Error");
+    }
+}
+
+int SocketError::GetError()
+{
+#ifdef _WIN32
+    return WSAGetLastError();
+#else
+    return errno;
+#endif
+}
+
+bool SocketError::IsNonBlockingError(int error)
+{
+#ifdef _WIN32
+    return error == WSAEINPROGRESS || error == WSAEWOULDBLOCK;
+#else
+    return error == EAGAIN || error == EWOULDBLOCK;
+#endif
+}
+
+bool SocketError::IsDisconnectError(int error)
+{
+#ifdef _WIN32
+    return error == WSAENOTCONN || error == WSAENETRESET || error == WSAESHUTDOWN;
+#else
+    return error == EBADF;
+#endif
+}

--- a/src/socketerrors.h
+++ b/src/socketerrors.h
@@ -1,0 +1,43 @@
+/******************************************************************************\
+ * Copyright (c) 2004-2020
+ *
+ * Author(s):
+ *  Aron Vietti
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Health Check
+ * This is currently just a TCP socket on the same port as the main Socket
+ * That accepts conncetions for the express puprpose of checking if the
+ * process is healthy. This helps in cloud environments, like AWS,
+ * for load balanaciing.
+\******************************************************************************/
+
+#pragma once
+
+namespace SocketError
+{
+
+void HandleSocketError(int error);
+
+int GetError();
+
+bool IsNonBlockingError(int error);
+
+bool IsDisconnectError(int error);
+
+}


### PR DESCRIPTION
 Many services, like AWS, do basic TCP Health Checks by connecting to the servers socket. UDP is not supported, so to make this work for Jamulus I created a HealthCheckSocket that handles connections on the same port as the UDP Service. To make that more meaningful it is on the same thread as the UDP socket. This could be expanded with more service checks in the future, but at the very least it will fail the HealthCheck if something is wrong on the thread.

To get this working I had to make both socket NonBlocking and use a select call to make sure the thread doesn't use CPU when there are no incoming messages or data.