### PR TITLE
optional INSTALL_PATH qmake flag (on unix)

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -302,11 +302,15 @@ DISTFILES_OBOE += libs/oboe/AUTHORS \
         android/sound.h \
         android/sound.cpp
 
-    # could this also be done for all platforms?
-    defined(INSTALL_PATH, var) {
-        INSTALLS += target
-        target.path = $$INSTALL_PATH
+    isEmpty(PREFIX) {
+        PREFIX = /usr/local
     }
+    isEmpty(BINDIR) {
+        BINDIR = bin
+    }
+    BINDIR = $$absolute_path($$BINDIR, $$PREFIX)
+    INSTALLS += target
+    target.path = $$BINDIR
 }
 
 RCC_DIR = src/res

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -301,6 +301,12 @@ DISTFILES_OBOE += libs/oboe/AUTHORS \
         android/AndroidManifest.xml \
         android/sound.h \
         android/sound.cpp
+
+    # could this also be done for all platforms?
+    defined(INSTALL_PATH, var) {
+        INSTALLS += target
+        target.path = $$INSTALL_PATH
+    }
 }
 
 RCC_DIR = src/res


### PR DESCRIPTION
I packaged Jamulus for nix/nixos and it would
be neat if there was an option to specify a
path at which to install the binary. I'm not
really familiar with qmake -- is this a good
way to achieve this?

(nixpkgs pull request: https://github.com/NixOS/nixpkgs/pull/87914)