### PR TITLE
Check the size of PROTMESSID_ACKN messages

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -556,6 +556,12 @@ if ( rand() < ( RAND_MAX / 2 ) ) return false;
         // special treatment for acknowledge messages
         if ( iRecID == PROTMESSID_ACKN )
         {
+            // check size
+            if ( vecbyMesBodyData.Size() != 2 )
+            {
+                return true; // return error code
+            }
+
             // extract data from stream and emit signal for received value
             int       iPos = 0;
             const int iData =


### PR DESCRIPTION
The Evaluate* functions that parse other types of messages all check the body size before starting to read data, but the special code for acknowledgements didn't do this, so an ACKN message on an existing connection that had a valid checksum but no body would result in an out-of-bounds read.

Found by fuzzing the protocol parser with [afl-fuzz](https://lcamtuf.coredump.cx/afl/), using messages from CTestbench as an initial corpus and disabling the CRC check. This was the only problem it found in a 24h fuzzing run.