### PR TITLE
[RFC] Add a "headless" build type which does not depend on QtGui/QtWidgets

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -10,9 +10,14 @@ CONFIG += qt \
     thread \
     release
 
-QT += widgets \
-    network \
+QT += network \
     xml
+
+!contains(CONFIG, "headless") {
+    QT += widgets
+} else {
+    QT -= gui
+}
 
 TRANSLATIONS = src/res/translation/translation_de_DE.ts \
     src/res/translation/translation_fr_FR.ts \
@@ -324,25 +329,18 @@ win32 {
 RCC_DIR = src/res
 RESOURCES += src/resources.qrc
 
-FORMS += src/clientdlgbase.ui \
+FORMS_GUI = src/clientdlgbase.ui \
     src/serverdlgbase.ui \
     src/clientsettingsdlgbase.ui \
     src/chatdlgbase.ui \
     src/connectdlgbase.ui \
     src/aboutdlgbase.ui
 
-HEADERS += src/audiomixerboard.h \
-    src/buffer.h \
+HEADERS += src/buffer.h \
     src/channel.h \
-    src/chatdlg.h \
     src/client.h \
-    src/clientsettingsdlg.h \
-    src/connectdlg.h \
     src/global.h \
-    src/clientdlg.h \
-    src/serverdlg.h \
     src/multicolorled.h \
-    src/multicolorledbar.h \
     src/protocol.h \
     src/server.h \
     src/serverlist.h \
@@ -352,12 +350,20 @@ HEADERS += src/audiomixerboard.h \
     src/soundbase.h \
     src/testbench.h \
     src/util.h \
-    src/analyzerconsole.h \
     src/recorder/jamrecorder.h \
     src/recorder/creaperproject.h \
     src/recorder/cwavestream.h \
     src/historygraph.h \
     src/signalhandler.h
+
+HEADERS_GUI = src/audiomixerboard.h \
+    src/chatdlg.h \
+    src/clientsettingsdlg.h \
+    src/connectdlg.h \
+    src/clientdlg.h \
+    src/serverdlg.h \
+    src/multicolorledbar.h \
+    src/analyzerconsole.h
 
 HEADERS_OPUS = libs/opus/celt/arch.h \
     libs/opus/celt/bands.h \
@@ -430,18 +436,10 @@ HEADERS_OPUS_X86 = libs/opus/celt/x86/celt_lpc_sse.h \
     libs/opus/celt/x86/vq_sse.h \
     libs/opus/celt/x86/x86cpu.h
 
-SOURCES += src/audiomixerboard.cpp \
-    src/buffer.cpp \
+SOURCES += src/buffer.cpp \
     src/channel.cpp \
-    src/chatdlg.cpp \
     src/client.cpp \
-    src/clientsettingsdlg.cpp \
-    src/connectdlg.cpp \
-    src/clientdlg.cpp \
-    src/serverdlg.cpp \
     src/main.cpp \
-    src/multicolorled.cpp \
-    src/multicolorledbar.cpp \
     src/protocol.cpp \
     src/server.cpp \
     src/serverlist.cpp \
@@ -451,11 +449,20 @@ SOURCES += src/audiomixerboard.cpp \
     src/socket.cpp \
     src/soundbase.cpp \
     src/util.cpp \
-    src/analyzerconsole.cpp \
     src/recorder/jamrecorder.cpp \
     src/recorder/creaperproject.cpp \
     src/recorder/cwavestream.cpp \
     src/historygraph.cpp
+
+SOURCES_GUI = src/audiomixerboard.cpp \
+    src/chatdlg.cpp \
+    src/clientsettingsdlg.cpp \
+    src/connectdlg.cpp \
+    src/clientdlg.cpp \
+    src/serverdlg.cpp \
+    src/multicolorled.cpp \
+    src/multicolorledbar.cpp \
+    src/analyzerconsole.cpp
 
 SOURCES_OPUS = libs/opus/celt/bands.c \
     libs/opus/celt/celt.c \
@@ -984,6 +991,14 @@ DISTFILES_OPUS += libs/opus/AUTHORS \
     libs/opus/README \
     libs/opus/celt/arm/armopts.s.in \
     libs/opus/celt/arm/celt_pitch_xcorr_arm.s \
+
+!contains(CONFIG, "headless") {
+    HEADERS += $$HEADERS_GUI
+    SOURCES += $$SOURCES_GUI
+    FORMS += $$FORMS_GUI
+} else {
+    DEFINES += HEADLESS
+}
 
 # use external OPUS library if requested
 contains(CONFIG, "opus_shared_lib") {

--- a/src/client.h
+++ b/src/client.h
@@ -28,7 +28,6 @@
 #include <QHostInfo>
 #include <QString>
 #include <QDateTime>
-#include <QMessageBox>
 #ifdef USE_OPUS_SHARED_LIB
 # include "opus/opus_custom.h"
 #else

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -33,6 +33,7 @@
 #include <QRadioButton>
 #include <QMenuBar>
 #include <QLayout>
+#include <QMessageBox>
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 # include <QVersionNumber>
 #endif

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -34,6 +34,7 @@
 #include <QMenuBar>
 #include <QLayout>
 #include <QButtonGroup>
+#include <QMessageBox>
 #include "global.h"
 #include "client.h"
 #include "multicolorled.h"

--- a/src/historygraph.cpp
+++ b/src/historygraph.cpp
@@ -299,6 +299,7 @@ void AHistoryGraph::AddMarker ( const SHistoryData& curHistoryData )
 
 
 /* JPEG History Graph implementation ******************************************/
+#ifndef HEADLESS
 CJpegHistoryGraph::CJpegHistoryGraph ( const int iMaxDaysHistory ) :
     AHistoryGraph   ( iMaxDaysHistory ),
     PlotPixmap      ( 1, 1, QImage::Format_RGB32 ),
@@ -401,6 +402,7 @@ void CJpegHistoryGraph::point ( const unsigned int x, const unsigned int y, cons
     PlotPainter.setPen ( QPen ( QBrush( QColor ( colour ) ), size ) );
     PlotPainter.drawPoint ( x, y );
 }
+#endif
 
 
 /* SVG History Graph implementation *******************************************/

--- a/src/historygraph.h
+++ b/src/historygraph.h
@@ -34,8 +34,10 @@
 #include "util.h"
 
 // for CJpegHistoryGraph
-#include <QImage>
-#include <QPainter>
+#ifndef HEADLESS
+# include <QImage>
+# include <QPainter>
+#endif
 
 // for CSvgHistoryGraph
 #include <QXmlStreamWriter>
@@ -134,6 +136,7 @@ protected:
 
 
 /* Implementations ************************************************************/
+#ifndef HEADLESS
 class CJpegHistoryGraph : public QObject, virtual public AHistoryGraph
 {
     Q_OBJECT
@@ -157,6 +160,7 @@ private:
 public slots:
     void OnTimerDailyUpdate() { Update(); }
 };
+#endif
 
 class CSvgHistoryGraph : public QObject, virtual public AHistoryGraph
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,15 +22,18 @@
  *
 \******************************************************************************/
 
-#include <QApplication>
-#include <QMessageBox>
+#include <QCoreApplication>
 #include <QDir>
 #include <QTextStream>
 #include <QTranslator>
 #include <QLibraryInfo>
 #include "global.h"
-#include "clientdlg.h"
-#include "serverdlg.h"
+#ifndef HEADLESS
+# include <QApplication>
+# include <QMessageBox>
+# include "clientdlg.h"
+# include "serverdlg.h"
+#endif
 #include "settings.h"
 #include "testbench.h"
 #include "util.h"
@@ -471,7 +474,7 @@ int main ( int argc, char** argv )
         if ( ( !strcmp ( argv[i], "--version" ) ) ||
              ( !strcmp ( argv[i], "-v" ) ) )
         {
-            tsConsole << CAboutDlg::GetVersionAndNameStr ( false ) << endl;
+            tsConsole << GetVersionAndNameStr ( false ) << endl;
             exit ( 1 );
         }
 
@@ -499,6 +502,14 @@ int main ( int argc, char** argv )
 #endif
     }
 
+#ifdef HEADLESS
+    if (bUseGUI)
+    {
+        bUseGUI = false;
+        tsConsole << "No GUI support compiled. Running in headless mode." << endl;
+    }
+#endif
+
 
     // Dependencies ------------------------------------------------------------
     // per definition: if we are in "GUI" server mode and no central server
@@ -523,9 +534,13 @@ int main ( int argc, char** argv )
     
     // Application/GUI setup ---------------------------------------------------
     // Application object
+#ifdef HEADLESS
+    QCoreApplication* pApp = new QCoreApplication ( argc, argv );
+#else
     QCoreApplication* pApp = bUseGUI
             ? new QApplication ( argc, argv )
             : new QCoreApplication ( argc, argv );
+#endif
 
 #ifdef ANDROID
     // special Android coded needed for record audio permission handling
@@ -602,6 +617,7 @@ int main ( int argc, char** argv )
             CSettings Settings ( &Client, strIniFileName );
             Settings.Load();
 
+#ifndef HEADLESS
             if ( bUseGUI )
             {
                 // GUI object
@@ -619,9 +635,10 @@ int main ( int argc, char** argv )
                 pApp->exec();
             }
             else
+#endif
             {
                 // only start application without using the GUI
-                tsConsole << CAboutDlg::GetVersionAndNameStr ( false ) << endl;
+                tsConsole << GetVersionAndNameStr ( false ) << endl;
 
                 pApp->exec();
             }
@@ -645,6 +662,7 @@ int main ( int argc, char** argv )
                              bDisconnectAllClientsOnQuit,
                              bUseDoubleSystemFrameSize,
                              eLicenceType );
+#ifndef HEADLESS
             if ( bUseGUI )
             {
                 // load settings from init-file
@@ -671,9 +689,10 @@ int main ( int argc, char** argv )
                 pApp->exec();
             }
             else
+#endif
             {
                 // only start application without using the GUI
-                tsConsole << CAboutDlg::GetVersionAndNameStr ( false ) << endl;
+                tsConsole << GetVersionAndNameStr ( false ) << endl;
 
                 // update serverlist
                 Server.UpdateServerList();
@@ -686,6 +705,7 @@ int main ( int argc, char** argv )
     catch ( CGenErr generr )
     {
         // show generic error
+#ifndef HEADLESS
         if ( bUseGUI )
         {
             QMessageBox::critical ( nullptr,
@@ -695,6 +715,7 @@ int main ( int argc, char** argv )
                                     nullptr );
         }
         else
+#endif
         {
             tsConsole << generr.GetErrorText() << endl;
         }

--- a/src/multicolorledbar.h
+++ b/src/multicolorledbar.h
@@ -24,12 +24,14 @@
 
 #pragma once
 
-#include <QFrame>
-#include <QPixmap>
-#include <QTimer>
-#include <QLayout>
-#include <QProgressBar>
-#include <QStackedLayout>
+#ifndef HEADLESS
+# include <QFrame>
+# include <QPixmap>
+# include <QTimer>
+# include <QLayout>
+# include <QProgressBar>
+# include <QStackedLayout>
+#endif
 #include "util.h"
 #include "global.h"
 
@@ -42,6 +44,7 @@
 
 
 /* Classes ********************************************************************/
+#ifndef HEADLESS
 class CMultiColorLEDBar : public QWidget
 {
     Q_OBJECT
@@ -95,3 +98,4 @@ protected:
     CVector<cLED*>  vecpLEDs;
     QProgressBar*   pProgressBar;
 };
+#endif

--- a/src/serverlogging.cpp
+++ b/src/serverlogging.cpp
@@ -47,13 +47,15 @@ void CServerLogging::Start ( const QString& strLoggingFileName )
 
 void CServerLogging::EnableHistory ( const QString& strHistoryFileName )
 {
-    if ( strHistoryFileName.right ( 4 ).compare ( ".svg", Qt::CaseInsensitive ) == 0 )
-    {
-        SvgHistoryGraph.Start ( strHistoryFileName );
-    }
-    else
+#ifndef HEADLESS
+    if ( strHistoryFileName.right ( 4 ).compare ( ".svg", Qt::CaseInsensitive ) != 0 )
     {
         JpegHistoryGraph.Start ( strHistoryFileName );
+    }
+    else
+#endif
+    {
+        SvgHistoryGraph.Start ( strHistoryFileName );
     }
 }
 
@@ -68,7 +70,9 @@ void CServerLogging::AddNewConnection ( const QHostAddress& ClientInetAddr )
     *this << strLogStr; // in log file
 
     // add element to history
+#ifndef HEADLESS
     JpegHistoryGraph.Add ( QDateTime::currentDateTime(), ClientInetAddr );
+#endif
     SvgHistoryGraph.Add ( QDateTime::currentDateTime(), ClientInetAddr );
 }
 
@@ -82,10 +86,14 @@ void CServerLogging::AddServerStopped()
     *this << strLogStr; // in log file
 
     // add element to history and update on server stop
+#ifndef HEADLESS
     JpegHistoryGraph.Add ( QDateTime::currentDateTime(), AHistoryGraph::HIT_SERVER_STOP );
+#endif
     SvgHistoryGraph.Add ( QDateTime::currentDateTime(), AHistoryGraph::HIT_SERVER_STOP );
 
+#ifndef HEADLESS
     JpegHistoryGraph.Update();
+#endif
     SvgHistoryGraph.Update();
 }
 
@@ -133,7 +141,9 @@ void CServerLogging::ParseLogFile ( const QString& strFileName )
                 if ( strAddress.isEmpty() )
                 {
                     // server stop
+#ifndef HEADLESS
                     JpegHistoryGraph.Add ( curDateTime, AHistoryGraph::HIT_SERVER_STOP );
+#endif
                     SvgHistoryGraph.Add ( curDateTime, CSvgHistoryGraph::HIT_SERVER_STOP );
                 }
                 else
@@ -144,7 +154,9 @@ void CServerLogging::ParseLogFile ( const QString& strFileName )
                     if ( curAddress.setAddress ( strlistCurLine.at ( 1 ).trimmed() ) )
                     {
                         // new client connection
+#ifndef HEADLESS
                         JpegHistoryGraph.Add ( curDateTime, curAddress );
+#endif
                         SvgHistoryGraph.Add ( curDateTime, curAddress );
                     }
                 }
@@ -152,7 +164,9 @@ void CServerLogging::ParseLogFile ( const QString& strFileName )
         }
     }
 
+#ifndef HEADLESS
     JpegHistoryGraph.Update();
+#endif
     SvgHistoryGraph.Update();
 }
 

--- a/src/serverlogging.h
+++ b/src/serverlogging.h
@@ -39,7 +39,9 @@ class CServerLogging
 {
 public:
     CServerLogging ( const int iMaxDaysHistory ) :
+#ifndef HEADLESS
         JpegHistoryGraph ( iMaxDaysHistory ),
+#endif
         SvgHistoryGraph ( iMaxDaysHistory ),
         bDoLogging ( false ),
         File ( DEFAULT_LOG_FILE_NAME ) {}
@@ -56,7 +58,9 @@ protected:
     void operator<< ( const QString& sNewStr );
     QString CurTimeDatetoLogString();
 
+#ifndef HEADLESS
     CJpegHistoryGraph JpegHistoryGraph;
+#endif
     CSvgHistoryGraph  SvgHistoryGraph;
     bool              bDoLogging;
     QFile             File;

--- a/src/socket.h
+++ b/src/socket.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <QObject>
-#include <QMessageBox>
 #include <QThread>
 #include <QMutex>
 #include <vector>

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -22,6 +22,10 @@
  *
 \******************************************************************************/
 
+#ifndef HEADLESS
+# include <QMessageBox>
+#endif
+
 #include "soundbase.h"
 
 
@@ -137,6 +141,7 @@ QString CSoundBase::SetDev ( const int iNewDev )
                 // the same driver is used but the driver properties seems to
                 // have changed so that they are not compatible to our
                 // software anymore
+#ifndef HEADLESS
                 QMessageBox::critical (
                     nullptr, APP_NAME, QString ( tr ( "The audio driver properties "
                     "have changed to a state which is incompatible with this "
@@ -145,6 +150,7 @@ QString CSoundBase::SetDev ( const int iNewDev )
                     strErrorMessage +
                     QString ( "</b><br><br>" + tr ( "Please restart the software." ) ),
                     tr ( "Close" ), nullptr );
+#endif
 
                 _exit ( 0 );
             }

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -26,7 +26,6 @@
 
 #include <QThread>
 #include <QString>
-#include <QMessageBox>
 #include "global.h"
 #include "util.h"
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -371,6 +371,7 @@ void CAudioReverb::Process ( CVector<int16_t>& vecsStereoInOut,
 * GUI Utilities                                                                *
 \******************************************************************************/
 // About dialog ----------------------------------------------------------------
+#ifndef HEADLESS
 CAboutDlg::CAboutDlg ( QWidget* parent ) : QDialog ( parent )
 {
     setupUi ( this );
@@ -454,43 +455,6 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : QDialog ( parent )
     // set window title
     setWindowTitle ( tr ( "About " ) + APP_NAME );
 }
-
-QString CAboutDlg::GetVersionAndNameStr ( const bool bWithHtml )
-{
-    QString strVersionText = "";
-
-    // name, short description and GPL hint
-    if ( bWithHtml )
-    {
-        strVersionText += "<b>";
-    }
-    else
-    {
-        strVersionText += " *** ";
-    }
-
-    strVersionText += APP_NAME + tr ( ", Version " ) + VERSION;
-
-    if ( bWithHtml )
-    {
-        strVersionText += "</b><br>";
-    }
-    else
-    {
-        strVersionText += "\n *** ";
-    }
-
-    if ( !bWithHtml )
-    {
-        strVersionText += tr ( "Internet Jam Session Software" );
-        strVersionText += "\n *** ";
-    }
-
-    strVersionText += tr ( "Released under the GNU General Public License (GPL)" );
-
-    return strVersionText;
-}
-
 
 // Licence dialog --------------------------------------------------------------
 CLicenceDlg::CLicenceDlg ( QWidget* parent ) : QDialog ( parent )
@@ -886,6 +850,7 @@ CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&
     addAction ( tr ( "&About..." ), this, SLOT ( OnHelpAbout() ) );
 }
 
+#endif
 
 /******************************************************************************\
 * Other Classes                                                                *
@@ -1427,4 +1392,40 @@ void DebugError ( const QString& pchErDescr,
     }
     printf ( "\nDebug error! For more information see test/DebugError.dat\n" );
     exit ( 1 );
+}
+
+QString GetVersionAndNameStr ( const bool bWithHtml )
+{
+    QString strVersionText = "";
+
+    // name, short description and GPL hint
+    if ( bWithHtml )
+    {
+        strVersionText += "<b>";
+    }
+    else
+    {
+        strVersionText += " *** ";
+    }
+
+    strVersionText += APP_NAME + QCoreApplication::tr ( ", Version " ) + VERSION;
+
+    if ( bWithHtml )
+    {
+        strVersionText += "</b><br>";
+    }
+    else
+    {
+        strVersionText += "\n *** ";
+    }
+
+    if ( !bWithHtml )
+    {
+        strVersionText += QCoreApplication::tr ( "Internet Jam Session Software" );
+        strVersionText += "\n *** ";
+    }
+
+    strVersionText += QCoreApplication::tr ( "Released under the GNU General Public License (GPL)" );
+
+    return strVersionText;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -24,19 +24,22 @@
 
 #pragma once
 
+#include <QCoreApplication>
 #include <QTcpSocket>
 #include <QHostAddress>
 #include <QHostInfo>
-#include <QMenu>
-#include <QWhatsThis>
-#include <QTextBrowser>
-#include <QLabel>
-#include <QCheckBox>
-#include <QComboBox>
-#include <QLineEdit>
-#include <QDateTime>
+#ifndef HEADLESS
+# include <QMenu>
+# include <QWhatsThis>
+# include <QTextBrowser>
+# include <QLabel>
+# include <QCheckBox>
+# include <QComboBox>
+# include <QLineEdit>
+# include <QDateTime>
+# include <QDesktopServices>
+#endif
 #include <QFile>
-#include <QDesktopServices>
 #include <QUrl>
 #include <QLocale>
 #include <QElapsedTimer>
@@ -56,7 +59,9 @@ using namespace std; // because of the library: "vector"
 #else
 # include <sys/time.h>
 #endif
-#include "ui_aboutdlgbase.h"
+#ifndef HEADLESS
+# include "ui_aboutdlgbase.h"
+#endif
 
 
 class CClient;  // forward declaration of CClient
@@ -100,6 +105,7 @@ inline int CalcBitRateBitsPerSecFromCodedBytes ( const int iCeltNumCodedBytes,
     return ( SYSTEM_SAMPLE_RATE_HZ * iCeltNumCodedBytes * 8 ) / iFrameSize;
 }
 
+QString GetVersionAndNameStr ( const bool bWithHtml = true );
 
 
 /******************************************************************************\
@@ -408,6 +414,7 @@ template<class TData> void CMovingAv<TData>::Add ( const TData tNewD )
 /******************************************************************************\
 * GUI Utilities                                                                *
 \******************************************************************************/
+#ifndef HEADLESS
 // About dialog ----------------------------------------------------------------
 class CAboutDlg : public QDialog, private Ui_CAboutDlgBase
 {
@@ -416,7 +423,6 @@ class CAboutDlg : public QDialog, private Ui_CAboutDlgBase
 public:
     CAboutDlg ( QWidget* parent = nullptr );
 
-    static QString GetVersionAndNameStr ( const bool bWithHtml = true );
 };
 
 
@@ -484,6 +490,7 @@ public slots:
     void OnHelpSoftwareMan()      { QDesktopServices::openUrl ( QUrl ( SOFTWARE_MANUAL_URL ) ); }
 };
 
+#endif
 
 // Console writer factory ------------------------------------------------------
 // this class was written by pljones


### PR DESCRIPTION
This allows building Jamulus without the huge GUI-related Qt packages and all of their dependencies, which on many systems includes a bunch of windowing system stuff. It's ideal for dedicated/hosted servers.

I basically just removed unnecessary source files from non-GUI builds, and then added a bunch of `#ifdef HEADLESS` around the GUI-specific portions of the source files that are common to both. Feedback welcome, I'm happy to make changes.

This was tested (built and run) on a server with only qtcore, qtxml, qtnetwork, as well as the full GUI build on a desktop machine with everything.