### PR TITLE
opus: fix equivalent bitrate calculation for <20ms frame sizes

### DIFF
--- a/libs/opus/celt/celt_encoder.c
+++ b/libs/opus/celt/celt_encoder.c
@@ -1571,7 +1571,7 @@ int celt_encode_with_ec(CELTEncoder * OPUS_RESTRICT st, const opus_val16 * pcm, 
                (tmp+4*mode->Fs)/(8*mode->Fs)-!!st->signalling));
       effectiveBytes = nbCompressedBytes - nbFilledBytes;
    }
-   equiv_rate = ((opus_int32)nbCompressedBytes*8*50 >> (3-LM)) - (40*C+20)*((400>>LM) - 50);
+   equiv_rate = ((opus_int32)nbCompressedBytes*8*50 << (3-LM)) - (40*C+20)*((400>>LM) - 50);
    if (st->bitrate != OPUS_BITRATE_MAX)
       equiv_rate = IMIN(equiv_rate, st->bitrate - (40*C+20)*((400>>LM) - 50));
 


### PR DESCRIPTION
This is a bugfix that I submitted to upstream Opus a few days ago. It
has been merged, but not released yet. Since it affects <20ms frame
sizes, which is what Jamulus uses, and affects audio quality
(particularly mono downmixes), it makes sense to merge this into
Jamulus' vendored Opus tree early.

Upstream issue: https://gitlab.xiph.org/xiph/opus/-/issues/2323