### PR TITLE
Feature/295 client side recording indicator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,9 +6,11 @@
 
 3.5.6git
 
-- enable/disable recording from command line, coded by pljones (#228)
+- add client-side server recording indicator, by pljones (#295)
 
 - add Audacity "list of files" writer to jam recorder, by pljones (#315)
+
+- enable/disable recording from command line and GUI, coded by pljones (#228)
 
 - make level meter LED black when off, by fleutot (#318)
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -121,7 +121,7 @@ CChannelFader::CChannelFader ( QWidget*     pNW,
     pMainGrid->addWidget ( pLabelInstBox );
 
     // add fader frame to audio mixer board layout
-    pParentLayout->addWidget( pFrame );
+    pParentLayout->addWidget ( pFrame );
 
     // reset current fader
     Reset();
@@ -603,18 +603,19 @@ double CChannelFader::CalcFaderGain ( const int value )
 * CAudioMixerBoard                                                             *
 \******************************************************************************/
 CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent, Qt::WindowFlags ) :
-    QGroupBox            ( parent ),
-    vecStoredFaderTags   ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
-    vecStoredFaderLevels ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
-    vecStoredPanValues   ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_PAN_MAX / 2 ),
-    vecStoredFaderIsSolo ( MAX_NUM_STORED_FADER_SETTINGS, false ),
-    vecStoredFaderIsMute ( MAX_NUM_STORED_FADER_SETTINGS, false ),
-    iNewClientFaderLevel ( 100 ),
-    bDisplayPans         ( false ),
-    bIsPanSupported      ( false ),
-    bNoFaderVisible      ( true ),
-    iMyChannelID         ( INVALID_INDEX ),
-    strServerName        ( "" )
+    QGroupBox               ( parent ),
+    vecStoredFaderTags      ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
+    vecStoredFaderLevels    ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
+    vecStoredPanValues      ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_PAN_MAX / 2 ),
+    vecStoredFaderIsSolo    ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+    vecStoredFaderIsMute    ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+    iNewClientFaderLevel    ( 100 ),
+    bDisplayPans            ( false ),
+    bIsPanSupported         ( false ),
+    bNoFaderVisible         ( true ),
+    iMyChannelID            ( INVALID_INDEX ),
+    strServerName           ( "" ),
+    strServerRecordingState ( "" )
 {
     // add group box and hboxlayout
     QHBoxLayout* pGroupBoxLayout = new QHBoxLayout ( this );
@@ -740,6 +741,19 @@ void CAudioMixerBoard::SetPanIsSupported()
     SetDisplayPans ( bDisplayPans );
 }
 
+void CAudioMixerBoard::SetServerRecordingState ( QString state )
+{
+    strServerRecordingState = state;
+    if ( !strServerName.isEmpty() )
+    {
+        QString strTitle = this->title().remove ( QRegExp ( "^\\[.\\] " ) );
+        if ( strTitle.mid ( 0, 1 ) != "\u2588" )
+        {
+            setTitle ( strServerRecordingState + " " + strTitle );
+        }
+    }
+}
+
 void CAudioMixerBoard::HideAll()
 {
     // make all controls invisible
@@ -769,7 +783,7 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
     // in the audio mixer board to show a "try to connect" before
     if ( bNoFaderVisible )
     {
-        setTitle ( tr ( "Personal Mix at the Server: " ) + strServerName );
+        setTitle ( strServerRecordingState + " " + tr ( "Personal Mix at the Server: " ) + strServerName );
     }
 
     // get number of connected clients

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -149,6 +149,7 @@ public:
     void SetDisplayChannelLevels ( const bool eNDCL );
     void SetDisplayPans ( const bool eNDP );
     void SetPanIsSupported();
+    void SetServerRecordingState ( QString state );
     void SetRemoteFaderIsMute ( const int iChannelIdx, const bool bIsMute );
     void SetMyChannelID ( const int iChannelIdx ) { iMyChannelID = iChannelIdx; }
 
@@ -202,6 +203,7 @@ protected:
     bool                    bNoFaderVisible;
     int                     iMyChannelID;
     QString                 strServerName;
+    QString                 strServerRecordingState;
 
     virtual void UpdateGainValue ( const int    iChannelIdx,
                                    const double dValue,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -191,6 +191,10 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLChannelLevelListReceived,
         this, &CClient::CLChannelLevelListReceived );
 
+    QObject::connect ( &ConnLessProtocol,
+        SIGNAL ( RecorderStateChange ( ESvrRecState ) ),
+        SIGNAL ( RecorderStateChange ( ESvrRecState ) ) );
+
     // other
     QObject::connect ( &Sound, &CSound::ReinitRequest,
         this, &CClient::OnSndCrdReinitRequest );

--- a/src/client.h
+++ b/src/client.h
@@ -425,6 +425,7 @@ signals:
     void MuteStateHasChangedReceived ( int iChanID, bool bIsMuted );
     void LicenceRequired ( ELicenceType eLicenceType );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
+    void RecorderStateChange ( ESvrRecState eState );
     void PingTimeReceived ( int iPingTime );
 
     void CLServerListReceived ( CHostAddress         InetAddr,

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -185,6 +185,12 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     // reset mixer board
     MainMixerBoard->HideAll();
 
+    MainMixerBoard->setAccessibleName ( tr ( "Personal Mix group box" ) );
+    MainMixerBoard->setWhatsThis ( "<b>" + tr ( "Personal Mix" ) + ":</b> "
+        + "Displays your local, per-channel settings of all channels on a server. "
+        + "The group box title displays an indicator of whether the server is recording, "
+        + "where this is known, along with the server name." );
+
     // restore channel level display preference
     MainMixerBoard->SetDisplayChannelLevels ( pClient->GetDisplayChannelLevels() );
 
@@ -489,6 +495,10 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     QObject::connect ( pClient, &CClient::VersionAndOSReceived,
         this, &CClientDlg::OnVersionAndOSReceived );
 
+    QObject::connect ( pClient,
+        SIGNAL ( RecorderStateChange ( ESvrRecState ) ),
+        this, SLOT ( OnRecorderStateChange ( ESvrRecState ) ) );
+
 #ifdef ENABLE_CLIENT_VERSION_AND_OS_DEBUGGING
     QObject::connect ( pClient, &CClient::CLVersionAndOSReceived,
         this, &CClientDlg::OnCLVersionAndOSReceived );
@@ -758,6 +768,11 @@ void CClientDlg::OnVersionAndOSReceived ( COSUtil::EOpSystemType ,
         MainMixerBoard->SetPanIsSupported();
     }
 #endif
+}
+
+void CClientDlg::OnRecorderStateChange ( ESvrRecState eState )
+{
+    MainMixerBoard->SetServerRecordingState ( csSvrRecStateToString ( eState ) );
 }
 
 void CClientDlg::OnChatTextReceived ( QString strChatText )
@@ -1075,6 +1090,9 @@ void CClientDlg::Connect ( const QString& strSelectedAddress,
         // change connect button text to "disconnect"
         butConnect->setText ( tr ( "D&isconnect" ) );
 
+        // set default recording state
+        MainMixerBoard->SetServerRecordingState ( csSvrRecStateToString ( ESvrRecState::RS_UNKNOWN ) );
+
         // set server name in audio mixer group box title
         MainMixerBoard->SetServerName ( strMixerBoardLabel );
 
@@ -1124,6 +1142,9 @@ OnTimerStatus();
 
     // clear mixer board (remove all faders)
     MainMixerBoard->HideAll();
+
+    // clear recording state
+    MainMixerBoard->SetServerRecordingState ( csSvrRecStateToString ( ESvrRecState::RS_UNKNOWN ) );
 }
 
 void CClientDlg::UpdateDisplay()

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -139,6 +139,8 @@ public slots:
     void OnVersionAndOSReceived ( COSUtil::EOpSystemType ,
                                   QString                strVersion );
 
+    void OnRecorderStateChange ( ESvrRecState eState );
+
 #ifdef ENABLE_CLIENT_VERSION_AND_OS_DEBUGGING
     void OnCLVersionAndOSReceived ( CHostAddress           InetAddr,
                                     COSUtil::EOpSystemType eOSType,

--- a/src/global.h
+++ b/src/global.h
@@ -189,8 +189,13 @@ LED bar:      lbr
 // defines the time interval at which the ping time is updated for the server list
 #define PING_UPDATE_TIME_SERVER_LIST_MS  2500 // ms
 
-// defines the interval between Channel Level updates from the server
-#define CHANNEL_LEVEL_UPDATE_INTERVAL    200  // number of frames at 64 samples frame size
+// defines the interval for low frequency updates from the server, currently:
+// - Channel Level
+#define LOW_FREQUENCY_UPDATE_INTERVAL    200  // number of frames at 64 samples frame size
+
+// defines the multiple of the low frequency interval for ultra low frequency updates, currently:
+// - Recorder Status
+#define ULTRA_LOW_FREQUENCY_LIMIT        5    // times the LOW_FREQUENCY_UPDATE_INTERVAL passes
 
 // time-out until a registered server is deleted from the server list if no
 // new registering was made in minutes

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -78,6 +78,7 @@
 #define PROTMESSID_CLM_REQ_CONN_CLIENTS_LIST  1014 // request the connected clients list
 #define PROTMESSID_CLM_CHANNEL_LEVEL_LIST     1015 // channel level list
 #define PROTMESSID_CLM_REGISTER_SERVER_RESP   1016 // status of server registration request
+#define PROTMESSID_CLM_RECORDER_STATE_CHANGED 1017 // new recording state of server
 
 // lengths of message as defined in protocol.cpp file
 #define MESS_HEADER_LENGTH_BYTE         7 // TAG (2), ID (2), cnt (1), length (2)
@@ -141,6 +142,8 @@ public:
                                          const int                iNumClients );
     void CreateCLRegisterServerResp    ( const CHostAddress& InetAddr,
                                          const ESvrRegResult eResult );
+    void CreateCLRecorderStateChange   ( const CHostAddress& InetAddr,
+                                         const ESvrRecState  eState );
 
     static bool ParseMessageFrame ( const CVector<uint8_t>& vecbyData,
                                     const int               iNumBytesIn,
@@ -263,6 +266,8 @@ protected:
                                            const CVector<uint8_t>& vecData );
     bool EvaluateCLRegisterServerResp    ( const CHostAddress&     InetAddr,
                                            const CVector<uint8_t>& vecData );
+    bool EvaluateCLRecorderStateChange   ( const CHostAddress&,
+                                           const CVector<uint8_t>& vecData );
 
     int                     iOldRecID;
     int                     iOldRecCnt;
@@ -302,6 +307,7 @@ signals:
     void LicenceRequired ( ELicenceType eLicenceType );
     void ReqChannelLevelList ( bool bOptIn );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
+    void RecorderStateChange ( ESvrRecState state );
 
     void CLPingReceived               ( CHostAddress           InetAddr,
                                         int                    iMs );

--- a/src/server.h
+++ b/src/server.h
@@ -279,6 +279,10 @@ protected:
     virtual void SendProtMessage ( int              iChID,
                                    CVector<uint8_t> vecMessage );
 
+    virtual void CreateAndSendRecorderStateForAllConChannels();
+
+    ESvrRecState GetRecorderState();
+
     template<unsigned int slotId>
     inline void connectChannelSignalsToServerSlots();
 
@@ -346,8 +350,11 @@ protected:
     // logging
     CServerLogging             Logging;
 
-    // channel level update frame interval counter
+    // low frequency update frame interval counter
     uint16_t                   iFrameCount;
+
+    // ultra-low frequency update frame interval counter
+    uint16_t                   iULFFrameCount;
 
     // recording thread
     recorder::CJamRecorder     JamRecorder;

--- a/src/testbench.h
+++ b/src/testbench.h
@@ -54,7 +54,7 @@ public:
 
         while ( !bSuccess && ( iPortIncrement <= 100 ) )
         {
-            bSuccess = UdpSocket.bind ( QHostAddress( QHostAddress::Any ),
+            bSuccess = UdpSocket.bind ( QHostAddress ( QHostAddress::Any ),
                                         22222 + iPortIncrement );
 
             iPortIncrement++;
@@ -99,7 +99,7 @@ protected:
         quint32 b = static_cast<quint32> ( 168 );
         quint32 c = static_cast<quint32> ( GenRandomIntInRange ( 1, 253 ) );
         quint32 d = static_cast<quint32> ( GenRandomIntInRange ( 1, 253 ) );
-        return QHostAddress( a << 24 | b << 16 | c << 8 | d );
+        return QHostAddress ( a << 24 | b << 16 | c << 8 | d );
     }
 
     QString    sAddress;
@@ -125,7 +125,7 @@ public slots:
         ESvrRegResult          eSvrRegResult;
 
         // generate random protocol message
-        switch ( GenRandomIntInRange ( 0, 34 ) )
+        switch ( GenRandomIntInRange ( 0, 35 ) )
         {
         case 0: // PROTMESSID_JITT_BUF_SIZE
             Protocol.CreateJitBufMes ( GenRandomIntInRange ( 0, 10 ) );
@@ -329,6 +329,12 @@ public slots:
 
         case 34: // PROTMESSID_CLIENT_ID
             Protocol.CreateClientIDMes ( GenRandomIntInRange ( -2, 20 ) );
+            break;
+
+        case 35: // PROTMESSID_CLM_RECORDER_STATE_CHANGED
+            Protocol.CreateCLRecorderStateChange ( CurHostAddress,
+                                                   static_cast<ESvrRecState> ( GenRandomIntInRange ( static_cast<int> ( ESvrRecState::RS_UNKNOWN ),
+                                                                                                     static_cast<int> ( ESvrRecState::RS_ENABLED ) ) ) );
             break;
         }
     }

--- a/src/util.h
+++ b/src/util.h
@@ -562,6 +562,36 @@ enum ELicenceType
 };
 
 
+// Server recorder state -------------------------------------------------
+enum ESvrRecState
+{
+    RS_UNKNOWN = 0,
+    RS_NOT_INITIALISED = 1,
+    RS_NOT_ENABLED = 2,
+    RS_ENABLED = 3
+};
+
+inline QString csSvrRecStateToString ( ESvrRecState eState )
+{
+    switch ( eState )
+    {
+    case RS_NOT_INITIALISED:
+        return QCoreApplication::translate ( "CAudioMixerBoard", "[-]" );
+
+    case RS_NOT_ENABLED:
+        return QCoreApplication::translate ( "CAudioMixerBoard", "[-]" );
+
+    case RS_ENABLED:
+        return QCoreApplication::translate ( "CAudioMixerBoard", "[R]" );
+
+    default:
+        break;
+    }
+
+    return QCoreApplication::translate ( "CAudioMixerBoard", "[?]" );
+}
+
+
 // Central server address type -------------------------------------------------
 enum ECSAddType
 {


### PR DESCRIPTION
Note that this is branched off 24f972c #228 feature/228-ui-for-recording-dir -- that pull request must go in first.  (There may not be clashes but that's the way around that I tested it.)

This is #295 - a status indication in the client of when the server is recording.  Unfortunately, prior to this version of the server, the client can't know for sure.  (I could have a server version test - below 3.4.4 it can't be recording.  There _are_ still 17 such servers out there on the Default central server...)