### PR TITLE
Install jamulus.desktop

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -295,12 +295,24 @@ win32 {
     isEmpty(PREFIX) {
         PREFIX = /usr/local
     }
+
     isEmpty(BINDIR) {
         BINDIR = bin
     }
     BINDIR = $$absolute_path($$BINDIR, $$PREFIX)
-    INSTALLS += target
     target.path = $$BINDIR
+    INSTALLS += target
+
+    isEmpty(APPSDIR) {
+        APPSDIR = share/applications
+    }
+    APPSDIR = $$absolute_path($$APPSDIR, $$PREFIX)
+    desktop.path = $$APPSDIR
+    desktop.files = distributions/jamulus.desktop
+    # the .desktop file assumes the binary is called jamulus
+    contains(CONFIG, "noupcasename") {
+        INSTALLS += desktop
+    }
 }
 
 RCC_DIR = src/res


### PR DESCRIPTION
As suggested in #223.

Because jamulus.desktop assumes the binary is called jamulus, and qmake doesn't have a mechanism for string expansion, only install the file so if noupcasename is set.