### PR TITLE
debian: Do not create home folder for jamulus system user

### DIFF
--- a/distributions/debian/postinst
+++ b/distributions/debian/postinst
@@ -4,6 +4,6 @@ set -e
 
 # dh_sysuser can be used in newer distro releases
 
-adduser --system --quiet jamulus
+adduser --system --quiet --home /nonexistent --no-create-home jamulus
 
 #DEBHELPER#


### PR DESCRIPTION
Lintian warning on Debian unstable.

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>