### PR TITLE
#295 Part 1: Define protocol message for server jam recorder state publishing

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -216,6 +216,17 @@ MESSAGES (with connection)
     note: does not have any data -> n = 0
 
 
+- PROTMESSID_RECORDER_STATE: notifies of changes in the server jam recorder state
+
+    +--------------+
+    | 1 byte state |
+    +--------------+
+
+    state is a value from the enum ERecorderState:
+    - 0 undefined (not used by protocol messages)
+    - tbc
+
+
 CONNECTION LESS MESSAGES
 ------------------------
 
@@ -658,6 +669,10 @@ if ( rand() < ( RAND_MAX / 2 ) ) return false;
 
             case PROTMESSID_VERSION_AND_OS:
                 bRet = EvaluateVersionAndOSMes ( vecbyMesBodyData );
+                break;
+
+            case PROTMESSID_RECORDER_STATE:
+                bRet = EvaluateRecorderStateMes ( vecbyMesBodyData );
                 break;
             }
 
@@ -1540,6 +1555,37 @@ bool CProtocol::EvaluateVersionAndOSMes ( const CVector<uint8_t>& vecData )
 
     // invoke message action
     emit VersionAndOSReceived ( eOSType, strVersion );
+
+    return false; // no error
+}
+
+void CProtocol::CreateRecorderStateMes ( const ERecorderState eRecorderState )
+{
+    CVector<uint8_t> vecData ( 1 ); // 1 byte of data
+    int              iPos = 0;      // init position pointer
+
+    // build data vector
+    // recorder state
+    PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( eRecorderState ), 1 );
+
+    CreateAndSendMessage ( PROTMESSID_RECORDER_STATE, vecData );
+}
+
+bool CProtocol::EvaluateRecorderStateMes(const CVector<uint8_t>& vecData)
+{
+    int iPos = 0; // init position pointer
+
+    // check size
+    if ( vecData.Size() != 1 )
+    {
+        return true; // return error code
+    }
+
+    // server jam recorder state
+    const ERecorderState eRecorderState = static_cast<ERecorderState> ( GetValFromStream ( vecData, iPos, 1 ) );
+
+    // invoke message action
+    emit RecorderStateReceived ( eRecorderState );
 
     return false; // no error
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -59,6 +59,7 @@
 #define PROTMESSID_CHANNEL_PAN                30 // set channel pan for mix
 #define PROTMESSID_MUTE_STATE_CHANGED         31 // mute state of your signal at another client has changed
 #define PROTMESSID_CLIENT_ID                  32 // current user ID and server status
+#define PROTMESSID_RECORDER_STATE             33 // contains the state of the jam recorder (ERecorderState)
 
 // message IDs of connection less messages (CLM)
 // DEFINITION -> start at 1000, end at 1999, see IsConnectionLessMessageID
@@ -114,6 +115,7 @@ public:
     void CreateOpusSupportedMes();
     void CreateReqChannelLevelListMes ( const bool bRCL );
     void CreateVersionAndOSMes();
+    void CreateRecorderStateMes ( const ERecorderState eRecorderState );
 
     void CreateCLPingMes               ( const CHostAddress& InetAddr, const int iMs );
     void CreateCLPingWithNumClientsMes ( const CHostAddress& InetAddr,
@@ -239,6 +241,7 @@ protected:
     bool EvaluateLicenceRequiredMes     ( const CVector<uint8_t>& vecData );
     bool EvaluateReqChannelLevelListMes ( const CVector<uint8_t>& vecData );
     bool EvaluateVersionAndOSMes        ( const CVector<uint8_t>& vecData );
+    bool EvaluateRecorderStateMes       ( const CVector<uint8_t>& vecData );
 
     bool EvaluateCLPingMes               ( const CHostAddress&     InetAddr,
                                            const CVector<uint8_t>& vecData );
@@ -302,6 +305,7 @@ signals:
     void LicenceRequired ( ELicenceType eLicenceType );
     void ReqChannelLevelList ( bool bOptIn );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
+    void RecorderStateReceived ( ERecorderState eRecorderState );
 
     void CLPingReceived               ( CHostAddress           InetAddr,
                                         int                    iMs );

--- a/src/util.h
+++ b/src/util.h
@@ -563,6 +563,14 @@ enum ELicenceType
 };
 
 
+// Server jam recorder state enum ----------------------------------------------
+enum ERecorderState
+{
+    RS_UNDEFINED = 0
+    // ... to be defined ...
+};
+
+
 // Channel sort type -----------------------------------------------------------
 enum EChSortType
 {


### PR DESCRIPTION
The enum will retain "0 undefined" for where the client never receives the protocol message.

The next change will be to the jam recorder (actually to the server - until I get back to adding the last bit of the Jam Recorder GUI changes, under which a some of what's currently there gets rewritten) to get it to emit values (along with adding them to the enum - carefully allowing for forwards and backwards compatibility by defining a complete and stable set of values......).