### PR TITLE
#295 Part 2: Define and send recorder state

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -168,6 +168,9 @@ public:
     void CreateConClientListMes ( const CVector<CChannelInfo>& vecChanInfo )
         { Protocol.CreateConClientListMes ( vecChanInfo ); }
 
+    void CreateRecorderStateMes ( const ERecorderState eRecorderState )
+        { Protocol.CreateRecorderStateMes ( eRecorderState ); }
+
     CNetworkTransportProps GetNetworkTransportPropsFromCurrentSettings();
 
     bool ChannelLevelsRequired() const                { return bChannelLevelsRequired; }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -610,6 +610,9 @@ void CServer::OnNewConnection ( int          iChID,
     // send version info (for, e.g., feature activation in the client)
     vecChannels[iChID].CreateVersionAndOSMes();
 
+    // send recording state message on connection
+    vecChannels[iChID].CreateRecorderStateMes ( GetRecorderState() );
+
     // reset the conversion buffers
     DoubleFrameSizeConvBufIn[iChID].Reset();
     DoubleFrameSizeConvBufOut[iChID].Reset();
@@ -721,6 +724,9 @@ void CServer::RequestNewRecording()
     {
         emit RestartRecorder();
     }
+
+    // send recording state message - doesn't hurt
+    CreateAndSendRecorderStateForAllConChannels();
 }
 
 void CServer::SetEnableRecording ( bool bNewEnableRecording )
@@ -747,6 +753,9 @@ void CServer::SetEnableRecording ( bool bNewEnableRecording )
             emit StopRecorder();
         }
     }
+
+    // send recording state message
+    CreateAndSendRecorderStateForAllConChannels();
 }
 
 void CServer::Start()
@@ -759,6 +768,9 @@ void CServer::Start()
 
         // emit start signal
         emit Started();
+
+        // send recording state message
+        CreateAndSendRecorderStateForAllConChannels();
     }
 }
 
@@ -778,6 +790,9 @@ void CServer::Stop()
 
         // emit stopped signal
         emit Stopped();
+
+        // send recording state message - to no one
+        CreateAndSendRecorderStateForAllConChannels();
     }
 }
 
@@ -1327,6 +1342,42 @@ void CServer::CreateAndSendChatTextForAllConChannels ( const int      iCurChanID
             // send message
             vecChannels[i].CreateChatTextMes ( strActualMessageText );
         }
+    }
+}
+
+void CServer::CreateAndSendRecorderStateForAllConChannels()
+{
+    // get recorder state
+    ERecorderState eRecorderState = GetRecorderState();
+
+    // now send recorder state to all connected clients
+    for ( int i = 0; i < iMaxNumChannels; i++ )
+    {
+        if ( vecChannels[i].IsConnected() )
+        {
+            // send message
+            vecChannels[i].CreateRecorderStateMes ( eRecorderState );
+        }
+    }
+}
+
+ERecorderState CServer::GetRecorderState()
+{
+    // return recorder state
+    if ( bRecorderInitialised )
+    {
+        if ( bEnableRecording )
+        {
+            return RS_RECORDING;
+        }
+        else
+        {
+            return RS_NOT_ENABLED;
+        }
+    }
+    else
+    {
+        return RS_NOT_INITIALISED;
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -273,6 +273,10 @@ protected:
     virtual void CreateAndSendChatTextForAllConChannels ( const int      iCurChanID,
                                                           const QString& strChatText );
 
+    virtual void CreateAndSendRecorderStateForAllConChannels();
+
+    ERecorderState GetRecorderState();
+
     virtual void CreateOtherMuteStateChanged ( const int  iCurChanID,
                                                const int  iOtherChanID,
                                                const bool bIsMuted );

--- a/src/util.h
+++ b/src/util.h
@@ -566,8 +566,10 @@ enum ELicenceType
 // Server jam recorder state enum ----------------------------------------------
 enum ERecorderState
 {
-    RS_UNDEFINED = 0
-    // ... to be defined ...
+    RS_UNDEFINED = 0,
+    RS_NOT_INITIALISED = 1,
+    RS_NOT_ENABLED = 2,
+    RS_RECORDING = 3
 };
 
 


### PR DESCRIPTION
Most of this currently lives in `server.cpp` as that's the "controller" for the state of the jam recorder.  Once the rewrite gets done, much of this will move out into the new `JamController` class...