### PR TITLE
#295 Part 3: Client side changes for recorder state - the end

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -619,13 +619,22 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent, Qt::WindowFlags ) :
     bIsPanSupported      ( false ),
     bNoFaderVisible      ( true ),
     iMyChannelID         ( INVALID_INDEX ),
-    strServerName        ( "" )
+    strServerName        ( "" ),
+    eRecorderState       ( RS_UNDEFINED )
 {
     // add group box and hboxlayout
     QHBoxLayout* pGroupBoxLayout = new QHBoxLayout ( this );
     QWidget*     pMixerWidget    = new QWidget(); // will be added to the scroll area which is then the parent
     pScrollArea                  = new CMixerBoardScrollArea ( this );
     pMainLayout                  = new QHBoxLayout ( pMixerWidget );
+
+
+    setAccessibleName ( "Personal Mix at the Server groupbox" );
+    setWhatsThis ( "<b>" + tr( "Personal Mix at the Server" ) + "</b>: " +
+        tr ( "When connected to a server, the controls here allow you to set " ) +
+        tr ( "your local mix without affecting what others hear from you.") + "<br/>" +
+        tr ( "The title shows the server name and, when known, "
+             "whether it is actively recording." ) );
 
     // set title text (default: no server given)
     SetServerName ( "" );
@@ -807,13 +816,32 @@ void CAudioMixerBoard::ChangeFaderOrder ( const bool        bDoSort,
     }
 }
 
+QString CAudioMixerBoard::GetTitle()
+{
+    QString myTitle = "";
+    if ( eRecorderState == RS_RECORDING )
+    {
+        myTitle = "[" + tr ( "RECORDING ACTIVE" )  + "] ";
+    }
+    return myTitle + tr ( "Personal Mix at: " ) + strServerName;
+}
+
+void CAudioMixerBoard::SetRecorderState ( const ERecorderState newRecorderState )
+{
+    eRecorderState = newRecorderState;
+    if ( !strServerName.isEmpty() && !bNoFaderVisible )
+    {
+        setTitle ( GetTitle() );
+    }
+}
+
 void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInfo )
 {
     // we want to set the server name only if the very first faders appear
     // in the audio mixer board to show a "try to connect" before
     if ( bNoFaderVisible )
     {
-        setTitle ( tr ( "Personal Mix at the Server: " ) + strServerName );
+        setTitle ( GetTitle() );
     }
 
     // get number of connected clients

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -164,6 +164,8 @@ public:
 
     void SetChannelLevels ( const CVector<uint16_t>& vecChannelLevel );
 
+    void SetRecorderState ( const ERecorderState newRecorderState );
+
     // settings
     CVector<QString> vecStoredFaderTags;
     CVector<int>     vecStoredFaderLevels;
@@ -188,6 +190,8 @@ protected:
         }
     };
 
+    QString GetTitle();
+
     bool GetStoredFaderSettings ( const CChannelInfo& ChanInfo,
                                   int&                iStoredFaderLevel,
                                   int&                iStoredPanValue,
@@ -209,6 +213,7 @@ protected:
     bool                    bNoFaderVisible;
     int                     iMyChannelID;
     QString                 strServerName;
+    ERecorderState          eRecorderState;
 
     virtual void UpdateGainValue ( const int    iChannelIdx,
                                    const double dValue,

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -108,6 +108,9 @@ qRegisterMetaType<CHostAddress> ( "CHostAddress" );
     QObject::connect ( &Protocol, &CProtocol::VersionAndOSReceived,
         this, &CChannel::VersionAndOSReceived );
 
+    QObject::connect ( &Protocol, &CProtocol::RecorderStateReceived,
+        this, &CChannel::RecorderStateReceived );
+
     QObject::connect ( &Protocol, &CProtocol::ReqChannelLevelList,
         this, &CChannel::OnReqChannelLevelList );
 }

--- a/src/channel.h
+++ b/src/channel.h
@@ -290,6 +290,7 @@ signals:
     void ReqNetTranspProps();
     void LicenceRequired ( ELicenceType eLicenceType );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
+    void RecorderStateReceived ( ERecorderState eRecorderState );
     void Disconnected();
 
     void DetectedCLMessage ( CVector<uint8_t> vecbyMesBodyData,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -165,6 +165,9 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &Channel, &CChannel::VersionAndOSReceived,
         this, &CClient::VersionAndOSReceived );
 
+    QObject::connect ( &Channel, &CChannel::RecorderStateReceived,
+        this, &CClient::RecorderStateReceived );
+
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLMessReadyForSending,
         this, &CClient::OnSendCLProtMessage );
 

--- a/src/client.h
+++ b/src/client.h
@@ -424,6 +424,7 @@ signals:
     void LicenceRequired ( ELicenceType eLicenceType );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );
     void PingTimeReceived ( int iPingTime );
+    void RecorderStateReceived ( ERecorderState eRecorderState );
 
     void CLServerListReceived ( CHostAddress         InetAddr,
                                 CVector<CServerInfo> vecServerInfo );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -472,6 +472,9 @@ CClientDlg::CClientDlg ( CClient*        pNCliP,
     QObject::connect ( pClient, &CClient::MuteStateHasChangedReceived,
         this, &CClientDlg::OnMuteStateHasChangedReceived );
 
+    QObject::connect ( pClient, &CClient::RecorderStateReceived,
+        this, &CClientDlg::OnRecorderStateReceived );
+
     // This connection is a special case. On receiving a licence required message via the
     // protocol, a modal licence dialog is opened. Since this blocks the thread, we need
     // a queued connection to make sure the core protocol mechanism is not blocked, too.

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -221,6 +221,9 @@ public slots:
     void OnDisplayChannelLevelsChanged()
         { MainMixerBoard->SetDisplayChannelLevels ( pClient->GetDisplayChannelLevels() ); }
 
+    void OnRecorderStateReceived ( ERecorderState eRecorderState )
+        { MainMixerBoard->SetRecorderState ( eRecorderState ); }
+
     void OnAudioChannelsChanged() { UpdateRevSelection(); }
     void OnNumClientsChanged ( int iNewNumClients );
     void OnNewClientLevelChanged() { MainMixerBoard->iNewClientFaderLevel = pClient->iNewClientFaderLevel; }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -740,7 +740,7 @@ void CServer::SetEnableRecording ( bool bNewEnableRecording )
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
 // TODO we should use the ConsoleWriterFactory() instead of qInfo()
-        qInfo() << "Recording state " << ( bEnableRecording ? "enabled" : "disabled" );
+        qInfo() << "Recording state" << ( bEnableRecording ? "enabled" : "disabled" );
 #endif
 
         if ( !bEnableRecording )


### PR DESCRIPTION
I've added the recording indicator like last time.  Code looks a little tidier, I think...  

I was wondering about the wiring of signals into CAudioMixerBoard - this is handled in CClientDlg by calling a public method, instead.  Is that OK?

Also, the "What's this" for the group box still feels rather heavily-weighted to explaining the indicator...