### PR TITLE
HTML-escape chat messages at the server

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1333,7 +1333,8 @@ void CServer::CreateAndSendChatTextForAllConChannels ( const int      iCurChanID
 
     const QString strActualMessageText =
         "<font color=""" + sCurColor + """>(" +
-        QTime::currentTime().toString ( "hh:mm:ss AP" ) + ") <b>" + ChanName +
+        QTime::currentTime().toString ( "hh:mm:ss AP" ) + ") <b>" +
+        ChanName.toHtmlEscaped() +
         "</b></font> " + strChatText;
 
 


### PR DESCRIPTION
At present, whatever text you include in your user name or chat messages is passed through directly to the chat display window and interpreted as HTML, which I don't think is intentional. This commit fixes it by having the server escape the message when it adds the channel name and timestamp.

It's not an ideal fix because the client is still trusting arbitrary HTML sent by the server (as it does for server welcome messages, and while external links don't work, cf #360, it can include things like `<img>` elements that reference local files, which isn't very nice). So maybe it'd be worth thinking about introducing a new type of protocol message where the channel name and text are separate fields?