### PR TITLE
Escape server and user names in the status HTML

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1590,7 +1590,7 @@ void CServer::WriteHTMLChannelList()
     }
 
     QTextStream streamFileOut ( &serverFileListFile );
-    streamFileOut << strServerNameWithPort << endl << "<ul>" << endl;
+    streamFileOut << strServerNameWithPort.toHtmlEscaped() << endl << "<ul>" << endl;
 
     // depending on number of connected clients write list
     if ( GetNumberOfConnectedClients() == 0 )
@@ -1605,7 +1605,7 @@ void CServer::WriteHTMLChannelList()
         {
             if ( vecChannels[i].IsConnected() )
             {
-                streamFileOut << "  <li>" << vecChannels[i].GetName() << "</li>" << endl;
+                streamFileOut << "  <li>" << vecChannels[i].GetName().toHtmlEscaped() << "</li>" << endl;
             }
         }
     }


### PR DESCRIPTION
Escape server and user names in the status HTML - currently if I set my username to something like `<i>AdamS` then it'll be passed through as is.

The security impact of this is limited by the name size limit that CProtocol enforces, and by this feature not being used on most servers anyway. (At worst, though, if somebody's ignored the sensible advice in the Tips page and directly included the output in a PHP file, it might be possible to execute arbitrary code on the webserver using crafted channel names.)