### PR TITLE
Fix two uninitialised reads

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -29,6 +29,7 @@
 CChannel::CChannel ( const bool bNIsServer ) :
     vecdGains              ( MAX_NUM_CHANNELS, 1.0 ),
     vecdPannings           ( MAX_NUM_CHANNELS, 0.5 ),
+    iCurSockBufNumFrames   ( -1 ),
     bDoAutoSockBufSize     ( true ),
     iFadeInCnt             ( 0 ),
     iFadeInCntMax          ( FADE_IN_NUM_FRAMES_DBLE_FRAMESIZE ),

--- a/src/signalhandler.cpp
+++ b/src/signalhandler.cpp
@@ -174,6 +174,7 @@ bool CSignalUnix::setSignalHandled ( int sigNum, bool state )
     else
     {
         sa.sa_handler = SIG_DFL;
+        sa.sa_flags = 0;
     }
 
     return ::sigaction ( sigNum, &sa, nullptr ) == 0;


### PR DESCRIPTION
Found using valgrind with fuzzer-generated testcases.