### PR TITLE
Fixed a bug that made the Server window stop updating

### DIFF
--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -762,5 +762,11 @@ void CServerDlg::changeEvent ( QEvent* pEvent )
             // the timer for this purpose
             QTimer::singleShot ( 0, this, SLOT ( hide() ) );
         }
+        else
+        {
+            // we have to call the show function from another thread -> use
+            // the timer for this purpose
+            QTimer::singleShot ( 0, this, SLOT ( show() ) );
+        }
     }
 }


### PR DESCRIPTION
Minimizing the Server Window on OSX stopped it from ever being
refreshed. Added a line to call show() when a changeEvent is
recieved and the window is not minimized.