### PR TITLE
UI to set (and clear) recording directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
 
 3.5.9git
 
+- update server UI to allow setting the jam recorder directory (like -R) (#228, #405)
+
 - new app icon for Jamulus, created by geheimerEichkater (#410)
 
 - bug fix: grouping faders in the client should be proportional (see discussion in #202, #419)

--- a/src/recorder/jamcontroller.cpp
+++ b/src/recorder/jamcontroller.cpp
@@ -90,6 +90,11 @@ void CJamController::SetRecordingDir ( QString newRecordingDir,
         strRecorderErrMsg = pJamRecorder->Init();
         bRecorderInitialised = ( strRecorderErrMsg == QString::null );
         bEnableRecording = bRecorderInitialised;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
+// TODO we should use the ConsoleWriterFactory() instead of qInfo()
+        qInfo() << "Recording state" << ( bEnableRecording ? "enabled" : "disabled" );
+#endif
     }
     else
     {
@@ -97,6 +102,11 @@ void CJamController::SetRecordingDir ( QString newRecordingDir,
         strRecorderErrMsg = QString::null;
         bRecorderInitialised = false;
         bEnableRecording = false;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
+// TODO we should use the ConsoleWriterFactory() instead of qInfo()
+        qInfo() << "Recording state not initialised";
+#endif
     }
 
     if ( bRecorderInitialised )

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -157,24 +157,25 @@ CServerDlg::CServerDlg ( CServer*         pNServP,
     // recorder status
     lblRecorderStatus->setAccessibleName ( tr ( "Recorder status label" ) );
     lblRecorderStatus->setWhatsThis ( "<b>" + tr ( "Recorder Status" ) + ":</b> "
-        + tr ( "Displays the current status of the recorder.  The following values are possible:"
-               "<dl>"
-               "<dt>Not initialised</dt>"
-               "<dd>No recording directory has been set or the value is not useable</dd>"
-               "<dt>Not enabled</dt>"
-               "<dd>Recording has been switched off" )
+        + tr ( "Displays the current status of the recorder.  The following values are possible:" )
+        + "<dl>"
+        + "<dt>" + tr ( SREC_NOT_INITIALISED ) + "</dt>"
+        + "<dd>" + tr ( "No recording directory has been set or the value is not useable" ) + "</dd>"
+        + "<dt>" + tr ( SREC_NOT_ENABLED ) + "</dt>"
+        + "<dd>" + tr ( "Recording has been switched off" )
 #ifdef _WIN32
-         + tr ( " by the UI checkbox</dd>" )
+        + tr ( " by the UI checkbox" )
 #else
-         + tr ( ", either by the UI checkbox or SIGUSR2 being received</dd>" )
+        + tr ( ", either by the UI checkbox or SIGUSR2 being received" )
 #endif
-         + tr ( "<dt>Not recording</dt>"
-                "<dd>There is no one connected to the server to record</dd>"
-                "<dt>Recording</dt>"
-                "<dd>The performers are being recorded to the specified session directory</dd>"
-                "</dl>" )
-        + tr ( "<br/><b>NOTE:</b> If the recording directory is not useable, "
-               "the problem will be displayed in place of the directory.") );
+        + "</dd>"
+        + "<dt>" + tr ( SREC_NOT_RECORDING ) + "</dt>"
+        + "<dd>" + tr ( "There is no one connected to the server to record" ) + "</dd>"
+        + "<dt>" + tr ( SREC_RECORDING ) + "</dt>"
+        + "<dd>" + tr ( "The performers are being recorded to the specified session directory" ) + "</dd>"
+        + "</dl>"
+        + "<br/><b>" + tr ( "NOTE" ) + ":</b> "
+        + tr ( "If the recording directory is not useable, the problem will be displayed in place of the directory." ) );
 
     // new recording
     pbtNewRecording->setAccessibleName ( tr ( "Request new recording button" ) );
@@ -781,17 +782,17 @@ void CServerDlg::UpdateRecorderStatus ( QString sessionDir )
             if ( pServer->IsRunning() )
             {
                 edtCurrentSessionDir->setText ( sessionDir != QString::null ? sessionDir : "" );
-                strRecorderStatus = tr ( "Recording" );
+                strRecorderStatus = tr ( SREC_RECORDING );
                 bIsRecording      = true;
             }
             else
             {
-                strRecorderStatus = tr ( "Not recording" );
+                strRecorderStatus = tr ( SREC_NOT_RECORDING );
             }
         }
         else
         {
-            strRecorderStatus = tr ( "Not enabled" );
+            strRecorderStatus = tr ( SREC_NOT_ENABLED );
         }
     }
     else
@@ -806,7 +807,7 @@ void CServerDlg::UpdateRecorderStatus ( QString sessionDir )
             strRecordingDir = tr ( "ERROR" ) + ": " + strRecordingDir;
         }
         chbEnableRecorder->setEnabled ( false );
-        strRecorderStatus = tr ( "Not initialised" );
+        strRecorderStatus = tr ( SREC_NOT_INITIALISED );
     }
 
     edtRecordingDir->setText( strRecordingDir );

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -46,6 +46,12 @@
 // update time for GUI controls
 #define GUI_CONTRL_UPDATE_TIME      1000 // ms
 
+// Strings used in multiple places
+#define SREC_NOT_INITIALISED "Not initialised"
+#define SREC_NOT_ENABLED     "Not enabled"
+#define SREC_NOT_RECORDING   "Not recording"
+#define SREC_RECORDING       "Recording"
+
 
 /* Classes ********************************************************************/
 class CServerDlg : public QDialog, private Ui_CServerDlgBase

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -35,6 +35,7 @@
 #include <QLayout>
 #include <QSystemTrayIcon>
 #include <QSettings>
+#include <QFileDialog>
 #include "global.h"
 #include "server.h"
 #include "settings.h"
@@ -111,6 +112,8 @@ public slots:
         { if ( e->key() != Qt::Key_Escape ) QDialog::keyPressEvent ( e ); }
 
     void OnNewRecordingClicked() { pServer->RequestNewRecording(); }
+    void OnRecordingDirClicked();
+    void OnClearRecordingDirClicked();
     void OnRecordingSessionStarted ( QString sessionDir )
         { UpdateRecorderStatus ( sessionDir ); }
 };

--- a/src/serverdlgbase.ui
+++ b/src/serverdlgbase.ui
@@ -172,9 +172,31 @@
    <item>
     <layout class="QHBoxLayout">
      <item>
+      <widget class="QPushButton" name="pbtRecordingDir">
+       <property name="text">
+        <string>Recording Directory</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="edtRecordingDir">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="tbtClearRecordingDir">
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
       <widget class="QCheckBox" name="chbEnableRecorder">
        <property name="text">
-        <string>Enable jam recorder</string>
+        <string>Enable Jam Recorder</string>
        </property>
       </widget>
      </item>
@@ -195,25 +217,7 @@
      <item>
       <widget class="QPushButton" name="pbtNewRecording">
        <property name="text">
-        <string>New recording</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QPushButton" name="pbtRecordingDir">
-       <property name="text">
-        <string>Recordings folder</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="edtRecordingsDir">
-       <property name="readOnly">
-        <bool>true</bool>
+        <string>New Recording</string>
        </property>
       </widget>
      </item>
@@ -276,11 +280,12 @@
   <tabstop>edtServerName</tabstop>
   <tabstop>edtLocationCity</tabstop>
   <tabstop>cbxLocationCountry</tabstop>
+  <tabstop>pbtRecordingDir</tabstop>
+  <tabstop>edtRecordingDir</tabstop>
+  <tabstop>tbtClearRecordingDir</tabstop>
   <tabstop>chbEnableRecorder</tabstop>
   <tabstop>edtCurrentSessionDir</tabstop>
   <tabstop>pbtNewRecording</tabstop>
-  <tabstop>pbtRecordingDir</tabstop>
-  <tabstop>edtRecordingsDir</tabstop>
  </tabstops>
  <resources>
   <include location="resources.qrc"/>


### PR DESCRIPTION
The UI change for the recording directory spec'd in #228.  I did, eventually, decide to put it above the session controls as you need the overall directory first.

I've extended the "What's this" on the status label, too, to be a bit more helpful.

----

Aside: `man jamulus` doesn't work.  I guess that's something else to think about.  Just basic command line options and signal handling, no description of how the UI works (that's the online manual's job).

^^
Please, no one reply to that - it's just so I've written it down _somewhere_...