### PR TITLE
Store recording directory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,7 +100,7 @@ int main ( int argc, char** argv )
         {
             bIsClient = false;
             tsConsole << "- server mode chosen" << endl;
-            CommandLineOptions += "--server";
+            CommandLineOptions << "--server";
             continue;
         }
 
@@ -113,7 +113,7 @@ int main ( int argc, char** argv )
         {
             bUseGUI = false;
             tsConsole << "- no GUI mode chosen" << endl;
-            CommandLineOptions += "--nogui";
+            CommandLineOptions << "--nogui";
             continue;
         }
 
@@ -127,7 +127,7 @@ int main ( int argc, char** argv )
             // right now only the creative commons licence is supported
             eLicenceType = LT_CREATIVECOMMONS;
             tsConsole << "- licence required" << endl;
-            CommandLineOptions += "--licence";
+            CommandLineOptions << "--licence";
             continue;
         }
 
@@ -140,7 +140,7 @@ int main ( int argc, char** argv )
         {
             bUseDoubleSystemFrameSize = false; // 64 samples frame size
             tsConsole << "- using " << SYSTEM_FRAME_SIZE_SAMPLES << " samples frame size mode" << endl;
-            CommandLineOptions += "--fastupdate";
+            CommandLineOptions << "--fastupdate";
             continue;
         }
 
@@ -161,7 +161,7 @@ int main ( int argc, char** argv )
             tsConsole << "- maximum number of channels: "
                 << iNumServerChannels << endl;
 
-            CommandLineOptions += "--numchannels";
+            CommandLineOptions << "--numchannels";
             continue;
         }
 
@@ -174,7 +174,7 @@ int main ( int argc, char** argv )
         {
             bStartMinimized = true;
             tsConsole << "- start minimized enabled" << endl;
-            CommandLineOptions += "--startminimized";
+            CommandLineOptions << "--startminimized";
             continue;
         }
 
@@ -187,7 +187,7 @@ int main ( int argc, char** argv )
         {
             bCentServPingServerInList = true;
             tsConsole << "- ping servers in slave server list" << endl;
-            CommandLineOptions += "--pingservers";
+            CommandLineOptions << "--pingservers";
             continue;
         }
 
@@ -200,7 +200,7 @@ int main ( int argc, char** argv )
         {
             bDisconnectAllClientsOnQuit = true;
             tsConsole << "- disconnect all clients on quit" << endl;
-            CommandLineOptions += "--discononquit";
+            CommandLineOptions << "--discononquit";
             continue;
         }
 
@@ -213,7 +213,7 @@ int main ( int argc, char** argv )
         {
             bNoAutoJackConnect = true;
             tsConsole << "- disable auto Jack connections" << endl;
-            CommandLineOptions += "--nojackconnect";
+            CommandLineOptions << "--nojackconnect";
             continue;
         }
 
@@ -226,7 +226,7 @@ int main ( int argc, char** argv )
         {
             bUseTranslation = false;
             tsConsole << "- translations disabled" << endl;
-            CommandLineOptions += "--notranslation";
+            CommandLineOptions << "--notranslation";
             continue;
         }
 
@@ -242,7 +242,7 @@ int main ( int argc, char** argv )
         {
             bShowComplRegConnList = true;
             tsConsole << "- show all registered servers in server list" << endl;
-            CommandLineOptions += "--showallservers";
+            CommandLineOptions << "--showallservers";
             continue;
         }
 
@@ -257,7 +257,7 @@ int main ( int argc, char** argv )
         {
             bShowAnalyzerConsole = true;
             tsConsole << "- show analyzer console" << endl;
-            CommandLineOptions += "--showanalyzerconsole";
+            CommandLineOptions << "--showanalyzerconsole";
             continue;
         }
 
@@ -275,7 +275,7 @@ int main ( int argc, char** argv )
         {
             iCtrlMIDIChannel = static_cast<int> ( rDbleArgument );
             tsConsole << "- selected controller MIDI channel: " << iCtrlMIDIChannel << endl;
-            CommandLineOptions += "--ctrlmidich";
+            CommandLineOptions << "--ctrlmidich";
             continue;
         }
 
@@ -291,7 +291,7 @@ int main ( int argc, char** argv )
         {
             strLoggingFileName = strArgument;
             tsConsole << "- logging file name: " << strLoggingFileName << endl;
-            CommandLineOptions += "--log";
+            CommandLineOptions << "--log";
             continue;
         }
 
@@ -310,7 +310,7 @@ int main ( int argc, char** argv )
             iPortNumber            = static_cast<quint16> ( rDbleArgument );
             bCustomPortNumberGiven = true;
             tsConsole << "- selected port number: " << iPortNumber << endl;
-            CommandLineOptions += "--port";
+            CommandLineOptions << "--port";
             continue;
         }
 
@@ -326,7 +326,7 @@ int main ( int argc, char** argv )
         {
             strHTMLStatusFileName = strArgument;
             tsConsole << "- HTML status file name: " << strHTMLStatusFileName << endl;
-            CommandLineOptions += "--htmlstatus";
+            CommandLineOptions << "--htmlstatus";
             continue;
         }
 
@@ -340,7 +340,7 @@ int main ( int argc, char** argv )
         {
             strServerName = strArgument;
             tsConsole << "- server name for HTML status file: " << strServerName << endl;
-            CommandLineOptions += "--servername";
+            CommandLineOptions << "--servername";
             continue;
         }
 
@@ -356,7 +356,7 @@ int main ( int argc, char** argv )
         {
             strClientName = QString ( APP_NAME ) + " " + strArgument;
             tsConsole << "- client name: " << strClientName << endl;
-            CommandLineOptions += "--clientname";
+            CommandLineOptions << "--clientname";
             continue;
         }
 
@@ -372,7 +372,7 @@ int main ( int argc, char** argv )
         {
             strRecordingDirName = strArgument;
             tsConsole << "- recording directory name: " << strRecordingDirName << endl;
-            CommandLineOptions += "--recording";
+            CommandLineOptions << "--recording";
             continue;
         }
 
@@ -388,7 +388,7 @@ int main ( int argc, char** argv )
         {
             strCentralServer = strArgument;
             tsConsole << "- central server: " << strCentralServer << endl;
-            CommandLineOptions += "--centralserver";
+            CommandLineOptions << "--centralserver";
             continue;
         }
 
@@ -404,7 +404,7 @@ int main ( int argc, char** argv )
         {
             strServerInfo = strArgument;
             tsConsole << "- server info: " << strServerInfo << endl;
-            CommandLineOptions += "--serverinfo";
+            CommandLineOptions << "--serverinfo";
             continue;
         }
 
@@ -420,7 +420,7 @@ int main ( int argc, char** argv )
         {
             strWelcomeMessage = strArgument;
             tsConsole << "- welcome message: " << strWelcomeMessage << endl;
-            CommandLineOptions += "--welcomemessage";
+            CommandLineOptions << "--welcomemessage";
             continue;
         }
 
@@ -436,7 +436,7 @@ int main ( int argc, char** argv )
         {
             strIniFileName = strArgument;
             tsConsole << "- initialization file name: " << strIniFileName << endl;
-            CommandLineOptions += "--inifile";
+            CommandLineOptions << "--inifile";
             continue;
         }
 
@@ -452,7 +452,7 @@ int main ( int argc, char** argv )
         {
             strConnOnStartupAddress = NetworkUtil::FixAddress ( strArgument );
             tsConsole << "- connect on startup to address: " << strConnOnStartupAddress << endl;
-            CommandLineOptions += "--connect";
+            CommandLineOptions << "--connect";
             continue;
         }
 
@@ -465,7 +465,7 @@ int main ( int argc, char** argv )
         {
             bMuteStream = true;
             tsConsole << "- mute stream activated" << endl;
-            CommandLineOptions += "--mutestream";
+            CommandLineOptions << "--mutestream";
             continue;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,9 +48,10 @@
 int main ( int argc, char** argv )
 {
 
-    QTextStream& tsConsole = *( ( new ConsoleWriterFactory() )->get() );
-    QString      strArgument;
-    double       rDbleArgument;
+    QTextStream&   tsConsole = *( ( new ConsoleWriterFactory() )->get() );
+    QString        strArgument;
+    double         rDbleArgument;
+    QList<QString> CommandLineOptions;
 
     // initialize all flags and string which might be changed by command line
     // arguments
@@ -99,6 +100,7 @@ int main ( int argc, char** argv )
         {
             bIsClient = false;
             tsConsole << "- server mode chosen" << endl;
+            CommandLineOptions += "--server";
             continue;
         }
 
@@ -111,6 +113,7 @@ int main ( int argc, char** argv )
         {
             bUseGUI = false;
             tsConsole << "- no GUI mode chosen" << endl;
+            CommandLineOptions += "--nogui";
             continue;
         }
 
@@ -124,6 +127,7 @@ int main ( int argc, char** argv )
             // right now only the creative commons licence is supported
             eLicenceType = LT_CREATIVECOMMONS;
             tsConsole << "- licence required" << endl;
+            CommandLineOptions += "--licence";
             continue;
         }
 
@@ -136,6 +140,7 @@ int main ( int argc, char** argv )
         {
             bUseDoubleSystemFrameSize = false; // 64 samples frame size
             tsConsole << "- using " << SYSTEM_FRAME_SIZE_SAMPLES << " samples frame size mode" << endl;
+            CommandLineOptions += "--fastupdate";
             continue;
         }
 
@@ -156,6 +161,7 @@ int main ( int argc, char** argv )
             tsConsole << "- maximum number of channels: "
                 << iNumServerChannels << endl;
 
+            CommandLineOptions += "--numchannels";
             continue;
         }
 
@@ -168,6 +174,7 @@ int main ( int argc, char** argv )
         {
             bStartMinimized = true;
             tsConsole << "- start minimized enabled" << endl;
+            CommandLineOptions += "--startminimized";
             continue;
         }
 
@@ -180,6 +187,7 @@ int main ( int argc, char** argv )
         {
             bCentServPingServerInList = true;
             tsConsole << "- ping servers in slave server list" << endl;
+            CommandLineOptions += "--pingservers";
             continue;
         }
 
@@ -192,6 +200,7 @@ int main ( int argc, char** argv )
         {
             bDisconnectAllClientsOnQuit = true;
             tsConsole << "- disconnect all clients on quit" << endl;
+            CommandLineOptions += "--discononquit";
             continue;
         }
 
@@ -204,6 +213,7 @@ int main ( int argc, char** argv )
         {
             bNoAutoJackConnect = true;
             tsConsole << "- disable auto Jack connections" << endl;
+            CommandLineOptions += "--nojackconnect";
             continue;
         }
 
@@ -216,6 +226,7 @@ int main ( int argc, char** argv )
         {
             bUseTranslation = false;
             tsConsole << "- translations disabled" << endl;
+            CommandLineOptions += "--notranslation";
             continue;
         }
 
@@ -231,6 +242,7 @@ int main ( int argc, char** argv )
         {
             bShowComplRegConnList = true;
             tsConsole << "- show all registered servers in server list" << endl;
+            CommandLineOptions += "--showallservers";
             continue;
         }
 
@@ -245,6 +257,7 @@ int main ( int argc, char** argv )
         {
             bShowAnalyzerConsole = true;
             tsConsole << "- show analyzer console" << endl;
+            CommandLineOptions += "--showanalyzerconsole";
             continue;
         }
 
@@ -262,6 +275,7 @@ int main ( int argc, char** argv )
         {
             iCtrlMIDIChannel = static_cast<int> ( rDbleArgument );
             tsConsole << "- selected controller MIDI channel: " << iCtrlMIDIChannel << endl;
+            CommandLineOptions += "--ctrlmidich";
             continue;
         }
 
@@ -277,6 +291,7 @@ int main ( int argc, char** argv )
         {
             strLoggingFileName = strArgument;
             tsConsole << "- logging file name: " << strLoggingFileName << endl;
+            CommandLineOptions += "--log";
             continue;
         }
 
@@ -295,6 +310,7 @@ int main ( int argc, char** argv )
             iPortNumber            = static_cast<quint16> ( rDbleArgument );
             bCustomPortNumberGiven = true;
             tsConsole << "- selected port number: " << iPortNumber << endl;
+            CommandLineOptions += "--port";
             continue;
         }
 
@@ -310,6 +326,7 @@ int main ( int argc, char** argv )
         {
             strHTMLStatusFileName = strArgument;
             tsConsole << "- HTML status file name: " << strHTMLStatusFileName << endl;
+            CommandLineOptions += "--htmlstatus";
             continue;
         }
 
@@ -323,6 +340,7 @@ int main ( int argc, char** argv )
         {
             strServerName = strArgument;
             tsConsole << "- server name for HTML status file: " << strServerName << endl;
+            CommandLineOptions += "--servername";
             continue;
         }
 
@@ -338,6 +356,7 @@ int main ( int argc, char** argv )
         {
             strClientName = QString ( APP_NAME ) + " " + strArgument;
             tsConsole << "- client name: " << strClientName << endl;
+            CommandLineOptions += "--clientname";
             continue;
         }
 
@@ -353,6 +372,7 @@ int main ( int argc, char** argv )
         {
             strRecordingDirName = strArgument;
             tsConsole << "- recording directory name: " << strRecordingDirName << endl;
+            CommandLineOptions += "--recording";
             continue;
         }
 
@@ -368,6 +388,7 @@ int main ( int argc, char** argv )
         {
             strCentralServer = strArgument;
             tsConsole << "- central server: " << strCentralServer << endl;
+            CommandLineOptions += "--centralserver";
             continue;
         }
 
@@ -383,6 +404,7 @@ int main ( int argc, char** argv )
         {
             strServerInfo = strArgument;
             tsConsole << "- server info: " << strServerInfo << endl;
+            CommandLineOptions += "--serverinfo";
             continue;
         }
 
@@ -398,6 +420,7 @@ int main ( int argc, char** argv )
         {
             strWelcomeMessage = strArgument;
             tsConsole << "- welcome message: " << strWelcomeMessage << endl;
+            CommandLineOptions += "--welcomemessage";
             continue;
         }
 
@@ -413,6 +436,7 @@ int main ( int argc, char** argv )
         {
             strIniFileName = strArgument;
             tsConsole << "- initialization file name: " << strIniFileName << endl;
+            CommandLineOptions += "--inifile";
             continue;
         }
 
@@ -428,6 +452,7 @@ int main ( int argc, char** argv )
         {
             strConnOnStartupAddress = NetworkUtil::FixAddress ( strArgument );
             tsConsole << "- connect on startup to address: " << strConnOnStartupAddress << endl;
+            CommandLineOptions += "--connect";
             continue;
         }
 
@@ -440,6 +465,7 @@ int main ( int argc, char** argv )
         {
             bMuteStream = true;
             tsConsole << "- mute stream activated" << endl;
+            CommandLineOptions += "--mutestream";
             continue;
         }
 
@@ -571,7 +597,7 @@ int main ( int argc, char** argv )
 
             // load settings from init-file
             CClientSettings Settings ( &Client, strIniFileName );
-            Settings.Load();
+            Settings.Load ( CommandLineOptions );
 
             // load translation
             if ( bUseGUI && bUseTranslation )
@@ -630,7 +656,7 @@ int main ( int argc, char** argv )
             {
                 // load settings from init-file
                 CServerSettings Settings ( &Server, strIniFileName );
-                Settings.Load();
+                Settings.Load ( CommandLineOptions );
 
                 // load translation
                 if ( bUseGUI && bUseTranslation )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -595,7 +595,7 @@ int main ( int argc, char** argv )
                              bNoAutoJackConnect,
                              strClientName );
 
-            // load settings from init-file
+            // load settings from init-file (command line options override)
             CClientSettings Settings ( &Client, strIniFileName );
             Settings.Load ( CommandLineOptions );
 
@@ -654,7 +654,7 @@ int main ( int argc, char** argv )
 #ifndef HEADLESS
             if ( bUseGUI )
             {
-                // load settings from init-file
+                // load settings from init-file (command line options override)
                 CServerSettings Settings ( &Server, strIniFileName );
                 Settings.Load ( CommandLineOptions );
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -26,7 +26,7 @@
 
 
 /* Implementation *************************************************************/
-void CSettings::Load()
+void CSettings::Load ( const QList<QString> CommandLineOptions )
 {
     // prepare file name for loading initialization data from XML file and read
     // data from file if possible
@@ -34,7 +34,7 @@ void CSettings::Load()
     ReadFromFile ( strFileName, IniXMLDocument );
 
     // read the settings from the given XML file
-    ReadSettingsFromXML ( IniXMLDocument );
+    ReadSettingsFromXML ( IniXMLDocument, CommandLineOptions );
 }
 
 void CSettings::Save()
@@ -248,7 +248,8 @@ void CClientSettings::SaveFaderSettings ( const QString& strCurFileName )
     WriteToFile ( strCurFileName, IniXMLDocument );
 }
 
-void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument )
+void CClientSettings::ReadSettingsFromXML ( const QDomDocument&  IniXMLDocument,
+                                            const QList<QString> )
 {
     int  iIdx;
     int  iValue;
@@ -780,7 +781,8 @@ void CClientSettings::WriteFaderSettingsToXML ( QDomDocument& IniXMLDocument )
 
 
 // Server settings -------------------------------------------------------------
-void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument )
+void CServerSettings::ReadSettingsFromXML ( const QDomDocument&  IniXMLDocument,
+                                            const QList<QString> CommandLineOptions )
 {
     int  iValue;
     bool bValue;
@@ -808,10 +810,13 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     }
 }
 
-    // central server address (to be set after the "use default central
-    // server address)
-    pServer->SetServerListCentralServerAddress (
-        GetIniSetting ( IniXMLDocument, "server", "centralservaddr" ) );
+    if ( !CommandLineOptions.contains( "--centralserver" ))
+    {
+        // central server address (to be set after the "use default central
+        // server address)
+        pServer->SetServerListCentralServerAddress (
+            GetIniSetting ( IniXMLDocument, "server", "centralservaddr" ) );
+    }
 
     // server list enabled flag
     if ( GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) )
@@ -826,7 +831,8 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     // name/city/country (command line overwrites setting file, note that
     // name/city/country are set by one single command line argument so we
     // can treat them combined here and it is sufficient to just check the name)
-    if ( pServer->GetServerName().isEmpty() )
+    //if ( pServer->GetServerName().isEmpty() )
+    if ( !CommandLineOptions.contains( "--serverinfo" ))
     {
         // name
         pServer->SetServerName ( GetIniSetting ( IniXMLDocument, "server", "name" ) );
@@ -843,13 +849,18 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     }
 
     // start minimized on OS start
-    if ( GetFlagIniSet ( IniXMLDocument, "server", "autostartmin", bValue ) )
+    if ( !CommandLineOptions.contains( "--startminimized" ) )
     {
-        pServer->SetAutoRunMinimized ( bValue );
+         if ( GetFlagIniSet ( IniXMLDocument, "server", "autostartmin", bValue ) )
+         {
+             pServer->SetAutoRunMinimized ( bValue );
+         }
     }
 
     // licence type (command line overwrites setting file)
-    if ( pServer->GetLicenceType() == LT_NO_LICENCE )
+    //if ( pServer->GetLicenceType() == LT_NO_LICENCE )
+    // TODO: command line needs to become boolean, at least...
+    if ( !CommandLineOptions.contains( "--licence" ) )
     {
         if ( GetNumericIniSet ( IniXMLDocument, "server", "licencetype",
              0, 1 /* LT_CREATIVECOMMONS */, iValue ) )
@@ -859,7 +870,8 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     }
 
     // welcome message (command line overwrites setting file)
-    if ( pServer->GetWelcomeMessage().isEmpty() )
+    //if ( pServer->GetWelcomeMessage().isEmpty() )
+    if ( !CommandLineOptions.contains( "--welcomemessage" ) )
     {
         pServer->SetWelcomeMessage ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "welcome" ) ) );
     }
@@ -869,7 +881,8 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
         GetIniSetting ( IniXMLDocument, "server", "winposmain_base64" ) );
 
     // base recording directory (command line overwrites setting file)
-    if ( pServer->GetRecordingDir().isEmpty() )
+    //if ( pServer->GetRecordingDir().isEmpty() )
+    if ( !CommandLineOptions.contains( "--recording" ) )
     {
         pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recordingdir_base64" ) ) );
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -867,6 +867,12 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     // window position of the main window
     vecWindowPosMain = FromBase64ToByteArray (
         GetIniSetting ( IniXMLDocument, "server", "winposmain_base64" ) );
+
+    // base recording directory (command line overwrites setting file)
+    if ( pServer->GetRecordingDir().isEmpty() )
+    {
+        pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recording_dir" ) ) );
+    }
 }
 
 void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
@@ -914,4 +920,8 @@ void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // window position of the main window
     PutIniSetting ( IniXMLDocument, "server", "winposmain_base64",
         ToBase64 ( vecWindowPosMain ) );
+
+    // base recording directory
+    PutIniSetting ( IniXMLDocument, "server", "recording_dir",
+        ToBase64 ( pServer->GetRecordingDir() ) );
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -871,7 +871,7 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     // base recording directory (command line overwrites setting file)
     if ( pServer->GetRecordingDir().isEmpty() )
     {
-        pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recording_dir" ) ) );
+        pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recordingdir_base64" ) ) );
     }
 }
 
@@ -922,6 +922,6 @@ void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
         ToBase64 ( vecWindowPosMain ) );
 
     // base recording directory
-    PutIniSetting ( IniXMLDocument, "server", "recording_dir",
+    PutIniSetting ( IniXMLDocument, "server", "recordingdir_base64",
         ToBase64 ( pServer->GetRecordingDir() ) );
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -828,10 +828,7 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     strLanguage = GetIniSetting ( IniXMLDocument, "server", "language",
                                   CLocale::FindSysLangTransFileName ( CLocale::GetAvailableTranslations() ).first );
 
-    // name/city/country (command line overwrites setting file, note that
-    // name/city/country are set by one single command line argument so we
-    // can treat them combined here and it is sufficient to just check the name)
-    //if ( pServer->GetServerName().isEmpty() )
+    // name/city/country
     if ( !CommandLineOptions.contains( "--serverinfo" ))
     {
         // name
@@ -869,8 +866,7 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
         }
     }
 
-    // welcome message (command line overwrites setting file)
-    //if ( pServer->GetWelcomeMessage().isEmpty() )
+    // welcome message
     if ( !CommandLineOptions.contains( "--welcomemessage" ) )
     {
         pServer->SetWelcomeMessage ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "welcome" ) ) );
@@ -880,8 +876,7 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     vecWindowPosMain = FromBase64ToByteArray (
         GetIniSetting ( IniXMLDocument, "server", "winposmain_base64" ) );
 
-    // base recording directory (command line overwrites setting file)
-    //if ( pServer->GetRecordingDir().isEmpty() )
+    // base recording directory
     if ( !CommandLineOptions.contains( "--recording" ) )
     {
         pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recordingdir_base64" ) ) );

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,7 +44,7 @@ public:
         strLanguage      ( "" ),
         strFileName      ( "" ) {}
 
-    void Load();
+    void Load ( const QList<QString> CommandLineOptions );
     void Save();
 
     // common settings
@@ -52,7 +52,7 @@ public:
     QString    strLanguage;
 
 protected:
-    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument ) = 0;
+    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString> CommandLineOptions ) = 0;
     virtual void WriteSettingsToXML  ( QDomDocument& IniXMLDocument )       = 0;
 
     void ReadFromFile ( const QString& strCurFileName,
@@ -170,7 +170,8 @@ public:
     bool       bWindowWasShownConnect;
 
 protected:
-    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument ) override;
+    // No CommandLineOptions used when reading Client inifile
+    virtual void ReadSettingsFromXML (const QDomDocument& IniXMLDocument, const QList<QString> ) override;
     virtual void WriteSettingsToXML  ( QDomDocument& IniXMLDocument ) override;
 
     void ReadFaderSettingsFromXML ( const QDomDocument& IniXMLDocument );
@@ -189,7 +190,7 @@ public:
         { SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME_SERVER); }
 
 protected:
-    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument ) override;
+    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString> CommandLineOptions ) override;
     virtual void WriteSettingsToXML  ( QDomDocument& IniXMLDocument ) override;
 
     CServer* pServer;


### PR DESCRIPTION
One problem.  Once set, there's no way from the command line to say "clear the base recording dir".  You can change it, but not clear it. (Same goes for some other strings.)