### PR TITLE
Accessibility: Less Verbosity for Connect/Disconnect

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -90,12 +90,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
         "If you are connected, pressing this button will end the session." ) );
 
     butConnect->setAccessibleName (
-        tr ( "Connect and disconnect toggle button" ) );
-
-    butConnect->setAccessibleDescription ( tr ( "Clicking on this "
-        "button changes the caption of the button from Connect to "
-        "Disconnect, i.e., it implements a toggle functionality for connecting "
-        "and disconnecting the application." ) );
+        tr ( "Connect and disconnect toggle" ) );
 
     // local audio input fader
     QString strAudFader = "<b>" + tr ( "Local Audio Input Fader" ) + ":</b> " +


### PR DESCRIPTION
Name of role doesn't need to be included in description/name. Screen readers automatically announce the role based on defined widget's role. Other wise, they'll hear "button" twice like "Connect and disconnect toggle button button."
When both name and description are set
1. NVDA and Jaws On windows ignore description and just announce name.
2. VoiceOver on Mac just ignores name, and announces description.
3. Narrator on Windows announces both.

In order for Mac users to hear what's set in setAccessibleName, they need to press vo+w. Also when the button is focused, instead of hearing "Connect and disconnect toggle," they hear "Clicking on this button changes the caption of the button from Connect to Disconnect, i.e., it implements a toggle functionality for connecting and disconnecting the application.."
