### PR TITLE
Added code to get jack latency

### DIFF
--- a/linux/sound.cpp
+++ b/linux/sound.cpp
@@ -25,6 +25,7 @@
 \******************************************************************************/
 
 #include "sound.h"
+//#include <iostream> // For debugging total latency
 
 #ifdef WITH_SOUND
 void CSound::OpenJack ( const bool  bNoAutoJackConnect,
@@ -151,6 +152,43 @@ void CSound::OpenJack ( const bool  bNoAutoJackConnect,
 
             jack_free ( ports );
         }
+
+        // Compute latency:
+        // We'l just use the first input and first output ports
+        // in determining latency. We'll also use the most
+        // optimistic values.
+
+        jack_latency_callback_mode_t cbmode;
+        jack_latency_range_t latrange;
+
+        // input latency
+
+        cbmode = JackCaptureLatency;
+        latrange.min = 0; 
+        latrange.max = 0 ;
+
+        jack_port_get_latency_range(input_port_left, cbmode, &latrange);
+        int inLatency = latrange.min; // be optimistic
+
+        // output latency 
+
+        cbmode = JackPlaybackLatency;
+        latrange.min = 0; 
+        latrange.max = 0 ;
+
+        jack_port_get_latency_range(output_port_left, cbmode, &latrange);
+        int outLatency = latrange.min; // be optimistic
+
+        int totalLatency = inLatency + outLatency;
+
+        dInOutLatencyMs = double(totalLatency) * 1000.0 / double(SYSTEM_SAMPLE_RATE_HZ);
+
+        // For debugging
+        //std::cout << "------------------------------------------------" << std::endl;
+        //std::cout << "frame delay = " << inLatency << " in + " << outLatency << " out " << std::endl;
+        //std::cout << "total latency = " << totalLatency << " frames, " << dInOutLatencyMs << " ms " << std::endl;
+        //std::cout << "------------------------------------------------" << std::endl;
+
     }
 }
 

--- a/linux/sound.h
+++ b/linux/sound.h
@@ -74,6 +74,8 @@ public:
     virtual void Start();
     virtual void Stop();
 
+    virtual double GetInOutLatencyMs() { return dInOutLatencyMs; }
+
     // these variables should be protected but cannot since we want
     // to access them from the callback function
     CVector<short> vecsTmpAudioSndCrdStereo;
@@ -98,6 +100,8 @@ protected:
     static int     bufferSizeCallback ( jack_nframes_t, void *arg );
     static void    shutdownCallback ( void* );
     jack_client_t* pJackClient;
+
+    double dInOutLatencyMs;
 };
 #else
 // no sound -> dummy class definition


### PR DESCRIPTION
After studying and using TheStk/RtAudio, I figured out how to get the latencies for audio devices when using Jamulus under Linux/Jack. The changes here were tested using two separate audio interfaces connected to a Raspberry Pi.