### PR TITLE
Use magic for unspecified length when storing WAV files

### DIFF
--- a/src/recorder/cwavestream.cpp
+++ b/src/recorder/cwavestream.cpp
@@ -123,26 +123,32 @@ void CWaveStream::waveStreamHeaders()
 
 void CWaveStream::finalise()
 {
-    static const uint32_t hdrRiffChunkSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
-    static const uint32_t fmtSubChunkSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t);
+    static const uint64_t hdrRiffChunkSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
+    static const uint64_t fmtSubChunkSize = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t);
 
-    static const uint32_t hdrRiffChunkSizeOffset = sizeof(uint32_t);
-    static const uint32_t dataSubChunkHdrChunkSizeOffset = hdrRiffChunkSize + fmtSubChunkSize + sizeof (uint32_t);
+    static const uint64_t hdrRiffChunkSizeOffset = sizeof(uint32_t);
+    static const uint64_t dataSubChunkHdrChunkSizeOffset = hdrRiffChunkSize + fmtSubChunkSize + sizeof (uint32_t);
 
     const int64_t currentPos = this->device()->pos();
-    const uint32_t fileLength = static_cast<uint32_t>(currentPos - initialPos);
+    const uint64_t fileLengthRiff = static_cast<uint64_t>(currentPos - initialPos - (hdrRiffChunkSizeOffset + sizeof (uint32_t)));
+    const uint64_t fileLengthData = static_cast<uint64_t>(currentPos - initialPos - (dataSubChunkHdrChunkSizeOffset + sizeof (uint32_t)));
 
-    QDataStream& out = static_cast<QDataStream&>(*this);
+    // check if lengths are within the range of the WAV file format
+    if (fileLengthRiff < 0x100000000ULL && fileLengthData < 0x100000000ULL)
+    {
+        QDataStream& out = static_cast<QDataStream&>(*this);
 
-    // Overwrite hdr_riff.chunkSize
-    this->device()->seek(initialPos + hdrRiffChunkSizeOffset);
-    out << static_cast<uint32_t>(fileLength - (hdrRiffChunkSizeOffset + sizeof (uint32_t)));
+        // Overwrite hdr_riff.chunkSize
+        this->device()->seek(initialPos + hdrRiffChunkSizeOffset);
+        out << static_cast<uint32_t>(fileLengthRiff);
 
-    // Overwrite dataSubChunkHdr.chunkSize
-    this->device()->seek(initialPos + dataSubChunkHdrChunkSizeOffset);
-    out << static_cast<uint32_t>(fileLength - (dataSubChunkHdrChunkSizeOffset + sizeof (uint32_t)));
+        // Overwrite dataSubChunkHdr.chunkSize
+        this->device()->seek(initialPos + dataSubChunkHdrChunkSizeOffset);
+        out << static_cast<uint32_t>(fileLengthData);
 
-    // and then restore the position and byte order
-    this->device()->seek(currentPos);
+        // And restore the position
+        this->device()->seek(currentPos);
+    }
+    // restore the byte order
     setByteOrder(initialByteOrder);
 }

--- a/src/recorder/cwavestream.h
+++ b/src/recorder/cwavestream.h
@@ -59,7 +59,7 @@ public:
     HdrRiff() {}
 
     static const uint32_t chunkId = 0x46464952; // RIFF
-    static const uint32_t chunkSize = 0xffffffff; // (will be overwritten) Size of file in bytes - 8 = size of data + 36
+    static const uint32_t chunkSize = 0x00000000; // unknown
     static const uint32_t format = 0x45564157; // WAVE
 };
 
@@ -88,7 +88,7 @@ public:
     DataSubChunkHdr() {}
 
     static const uint32_t chunkId = 0x61746164; // "data"
-    static const uint32_t chunkSize = 0xffffffff; // (will be overwritten) Size of data
+    static const uint32_t chunkSize = 0x7ffff000; // magic for unspecified length
 };
 
 class CWaveStream : public QDataStream


### PR DESCRIPTION
They can easily be bigger than the supported maximum of 4GBytes.

Tested using:
Audacity
VLC
SOX

Quote from SOX documentation:

```
/* Magic length writen when its not possible to write valid lengths.
 * This can be either because of non-seekable output or because
 * the length can not be represented by the 32-bits used in WAV files.
 * When magic length is detected on inputs, disable any length
 * logic.
 */
#define MS_UNSPEC 0x7ffff000
```

Signed-off-by: Hans Petter Selasky <hps@selasky.org>