### PR TITLE
Change server log message when idling

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -756,7 +756,7 @@ void CServer::Start()
     }
 }
 
-void CServer::Stop()
+void CServer::Stop(bool indicate_idling)
 {
     // Under Mac we have the problem that the timer shutdown might
     // take some time and therefore we get a lot of "server stopped"
@@ -768,12 +768,21 @@ void CServer::Stop()
         HighPrecisionTimer.Stop();
 
         // logging (add "server stopped" logging entry)
-        Logging.AddServerStopped();
+
+        if (indicate_idling)
+        {
+            Logging.AddServerStopped(",, server idling");
+        }
+        else 
+        {
+            Logging.AddServerStopped(",, server stopped");
+        }
 
         // emit stopped signal
         emit Stopped();
     }
 }
+
 
 void CServer::OnTimer()
 {
@@ -1032,7 +1041,8 @@ static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TE
     {
         // Disable server if no clients are connected. In this case the server
         // does not consume any significant CPU when no client is connected.
-        Stop();
+        bool indicate_idling = true;
+        Stop(indicate_idling);
     }
 
     Q_UNUSED ( iUnused )

--- a/src/server.h
+++ b/src/server.h
@@ -189,7 +189,8 @@ public:
     virtual ~CServer();
 
     void Start();
-    void Stop();
+    void Stop(bool indicate_idling = false);
+
     bool IsRunning() { return HighPrecisionTimer.isActive(); }
 
     bool PutAudioData ( const CVector<uint8_t>& vecbyRecBuf,

--- a/src/serverlogging.cpp
+++ b/src/serverlogging.cpp
@@ -57,9 +57,10 @@ void CServerLogging::AddNewConnection ( const QHostAddress& ClientInetAddr,
     *this << strLogStr; // in log file
 }
 
-void CServerLogging::AddServerStopped()
+void CServerLogging::AddServerStopped(const QString &msgSuffix)
 {
-    const QString strLogStr = CurTimeDatetoLogString() + ",, server stopped "
+
+    const QString strLogStr = CurTimeDatetoLogString() + msgSuffix + 
         "-------------------------------------";
 
     QTextStream& tsConsoleStream = *( ( new ConsoleWriterFactory() )->get() );

--- a/src/serverlogging.h
+++ b/src/serverlogging.h
@@ -44,7 +44,7 @@ public:
     virtual ~CServerLogging();
 
     void Start ( const QString& strLoggingFileName );
-    void AddServerStopped();
+    void AddServerStopped( const QString& msgSuffix );
 
     void AddNewConnection ( const QHostAddress& ClientInetAddr,
                             const int           iNumberOfConnectedClients );


### PR DESCRIPTION
When a server has no more clients connected, the server log will show the message "server stopped". I propose this be changed to "server idling" for this case. When I see "server stopped" it makes me think the server has shutdown for some reason and is no longer running. So I go to restart it only to see it's already running.