### PR TITLE
Daily Update Checker (on start up)

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -353,6 +353,7 @@ HEADERS += src/buffer.h \
     src/socket.h \
     src/soundbase.h \
     src/testbench.h \
+    src/updatetool.h \
     src/util.h \
     src/recorder/jamrecorder.h \
     src/recorder/creaperproject.h \
@@ -452,6 +453,7 @@ SOURCES += src/buffer.cpp \
     src/signalhandler.cpp \
     src/socket.cpp \
     src/soundbase.cpp \
+    src/updatetool.cpp \
     src/util.cpp \
     src/recorder/jamrecorder.cpp \
     src/recorder/creaperproject.cpp \

--- a/src/aboutdlgbase.ui
+++ b/src/aboutdlgbase.ui
@@ -94,6 +94,10 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QPushButton" name="btnCheckForUpdates">
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -23,10 +23,12 @@
 \******************************************************************************/
 
 #include "clientdlg.h"
+#include "updatetool.h"
 
 
 /* Implementation *************************************************************/
 CClientDlg::CClientDlg ( CClient*         pNCliP,
+                         CUpdateTool*     pUpdateTool,
                          CClientSettings* pNSetP,
                          const QString&   strConnOnStartupAddress,
                          const int        iCtrlMIDIChannel,
@@ -288,11 +290,10 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     // Main menu bar -----------------------------------------------------------
     QMenuBar* pMenu = new QMenuBar ( this );
-
     pMenu->addMenu ( pFileMenu );
     pMenu->addMenu ( pViewMenu );
     pMenu->addMenu ( pEditMenu );
-    pMenu->addMenu ( new CHelpMenu ( true, this ) );
+    pMenu->addMenu ( new CHelpMenu ( true, pUpdateTool, this ) );
 
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -74,6 +74,7 @@ class CClientDlg : public QDialog, private Ui_CClientDlgBase
 
 public:
     CClientDlg ( CClient*         pNCliP,
+                 CUpdateTool*     pUpdateTool,
                  CClientSettings* pNSetP,
                  const QString&   strConnOnStartupAddress,
                  const int        iCtrlMIDIChannel,

--- a/src/global.h
+++ b/src/global.h
@@ -111,6 +111,12 @@ LED bar:      lbr
 #define SERVER_GETTING_STARTED_URL       "https://github.com/corrados/jamulus/wiki/Running-a-Server"
 #define SOFTWARE_MANUAL_URL              "https://github.com/corrados/jamulus/blob/master/src/res/homepage/manual.md"
 
+// update tool URLs
+#define SOFTWARE_LATEST_RELEASE_URL      "https://api.github.com/repos/corrados/jamulus/releases/latest"
+// Following has <release> substituted by the release "name" from the above
+#define SOFTWARE_CHANGELOG_URL           "https://raw.githubusercontent.com/corrados/jamulus/<release>/ChangeLog"
+#define SOFTWARE_DOWNLOAD_URL            "https://sourceforge.net/projects/llcon/"
+
 // determining server internal address uses well-known host and port
 // (Google DNS, or something else reliable)
 #define WELL_KNOWN_HOST                  "8.8.8.8" // Google

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -547,13 +547,6 @@ int main ( int argc, char** argv )
 
 
     // Dependencies ------------------------------------------------------------
-    // per definition: if we are in "GUI" server mode and no central server
-    // address is given, we use the default central server address
-    if ( !bIsClient && bUseGUI && strCentralServer.isEmpty() )
-    {
-        strCentralServer = DEFAULT_SERVER_ADDRESS;
-    }
-
     // adjust default port number for client: use different default port than the server since
     // if the client is started before the server, the server would get a socket bind error
     if ( bIsClient && !bCustomPortNumberGiven )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -684,19 +684,20 @@ int main ( int argc, char** argv )
                              bUseMultithreading,
                              eLicenceType );
 
+            // load settings from init-file (command line options override)
+            CServerSettings Settings ( &Server, strIniFileName );
+            Settings.Load ( CommandLineOptions );
+
+            // load translation
+            if ( bUseGUI && bUseTranslation )
+            {
+                CLocale::LoadTranslation ( Settings.strLanguage, pApp );
+            }
+
+
 #ifndef HEADLESS
             if ( bUseGUI )
             {
-                // load settings from init-file (command line options override)
-                CServerSettings Settings ( &Server, strIniFileName );
-                Settings.Load ( CommandLineOptions );
-
-                // load translation
-                if ( bUseGUI && bUseTranslation )
-                {
-                    CLocale::LoadTranslation ( Settings.strLanguage, pApp );
-                }
-
                 // update server list AFTER restoring the settings from the
                 // settings file
                 Server.UpdateServerList();

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -23,10 +23,12 @@
 \******************************************************************************/
 
 #include "serverdlg.h"
+#include "updatetool.h"
 
 
 /* Implementation *************************************************************/
 CServerDlg::CServerDlg ( CServer*         pNServP,
+                         CUpdateTool*     pUpdateTool,
                          CServerSettings* pNSetP,
                          const bool       bStartMinimized,
                          QWidget*         parent,
@@ -364,9 +366,8 @@ lvwClients->setMinimumHeight ( 140 );
 
     // Main menu bar -----------------------------------------------------------
     pMenu = new QMenuBar ( this );
-
     pMenu->addMenu ( pViewMenu );
-    pMenu->addMenu ( new CHelpMenu ( false, this ) );
+    pMenu->addMenu ( new CHelpMenu ( false, pUpdateTool, this ) );
 
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -60,6 +60,7 @@ class CServerDlg : public QDialog, private Ui_CServerDlgBase
 
 public:
     CServerDlg ( CServer*         pNServP,
+                 CUpdateTool*     pUpdateTool,
                  CServerSettings* pNSetP,
                  const bool       bStartMinimized,
                  QWidget*         parent = nullptr,

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -523,6 +523,30 @@ if ( GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) )
 
     // fader settings
     ReadFaderSettingsFromXML ( IniXMLDocument );
+
+    if ( !CommandLineOptions.contains ( "--updatetool" ) )
+    {
+        // User's choice (or UT_ASK) for daily update checking
+        if ( GetNumericIniSet ( IniXMLDocument, "client", "updatetooldailyupdatechecktype",
+             0, static_cast<int> ( UT_NEVER ), iValue ) )
+        {
+            eUTDailyUpdateCheckType = static_cast<EUTCheckType> ( iValue );
+        }
+        else
+        {
+            eUTDailyUpdateCheckType = UT_ASK; // which is zero, anyway
+        }
+    }
+
+    // UTC date of last update check, else epoch
+    dtUTLastCheck = QDateTime::fromString ( FromBase64ToString (
+        GetIniSetting ( IniXMLDocument, "client", "updatetoollastcheck_base64",
+                        base64DefaultLastCheck ) ), Qt::ISODate );
+
+    // Offered version the user last chose to skip
+    strUTLastSkippedVersion = FromBase64ToString (
+        GetIniSetting ( IniXMLDocument, "client", "updatetoollastskippedversion_base64",
+                        base64DefaultLastSkippedVersion ) );
 }
 
 void CClientSettings::ReadFaderSettingsFromXML ( const QDomDocument& IniXMLDocument )
@@ -739,6 +763,18 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
 
     // fader settings
     WriteFaderSettingsToXML ( IniXMLDocument );
+
+    // User's choice for daily update checking
+    SetNumericIniSet ( IniXMLDocument, "client", "updatetooldailyupdatechecktype",
+        static_cast<int> ( eUTDailyUpdateCheckType ) );
+
+    // UTC date of last update check
+    PutIniSetting ( IniXMLDocument, "client", "updatetoollastcheck_base64",
+        ToBase64 ( dtUTLastCheck.toString ( Qt::ISODate ) ) );
+
+    // Offered version the user last chose to skip
+    PutIniSetting ( IniXMLDocument, "client", "updatetoollastskippedversion_base64",
+        ToBase64 ( strUTLastSkippedVersion ) );
 }
 
 void CClientSettings::WriteFaderSettingsToXML ( QDomDocument& IniXMLDocument )
@@ -890,6 +926,30 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     {
         pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recordingdir_base64" ) ) );
     }
+
+    // User's choice (or UT_ASK) for daily update checking
+    if ( !CommandLineOptions.contains ( "--updatetool" ) )
+    {
+        if ( GetNumericIniSet ( IniXMLDocument, "server", "updatetooldailyupdatechecktype",
+             0, static_cast<int> ( UT_NEVER ), iValue ) )
+        {
+            eUTDailyUpdateCheckType = static_cast<EUTCheckType> ( iValue );
+        }
+        else
+        {
+            eUTDailyUpdateCheckType = UT_ASK; // which is zero, anyway
+        }
+    }
+
+    // UTC date of last update check, else epoch
+    dtUTLastCheck = QDateTime::fromString ( FromBase64ToString (
+        GetIniSetting ( IniXMLDocument, "server", "updatetoollastcheck_base64",
+                        base64DefaultLastCheck ) ), Qt::ISODate );
+
+    // Offered version the user last chose to skip
+    strUTLastSkippedVersion = FromBase64ToString (
+        GetIniSetting ( IniXMLDocument, "server", "updatetoollastskippedversion_base64",
+                        base64DefaultLastSkippedVersion ) );
 }
 
 void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
@@ -941,4 +1001,16 @@ void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // base recording directory
     PutIniSetting ( IniXMLDocument, "server", "recordingdir_base64",
         ToBase64 ( pServer->GetRecordingDir() ) );
+
+    // User's choice for daily update checking
+    SetNumericIniSet ( IniXMLDocument, "server", "updatetooldailyupdatechecktype",
+        static_cast<int> ( eUTDailyUpdateCheckType ) );
+
+    // UTC date of last update check
+    PutIniSetting ( IniXMLDocument, "server", "updatetoollastcheck_base64",
+        ToBase64 ( dtUTLastCheck.toString ( Qt::ISODate ) ) );
+
+    // Offered version the user last chose to skip
+    PutIniSetting ( IniXMLDocument, "server", "updatetoollastskippedversion_base64",
+        ToBase64 ( strUTLastSkippedVersion ) );
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -812,10 +812,21 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
 
     if ( !CommandLineOptions.contains ( "--centralserver" ) )
     {
+        QString strCentralServer = GetIniSetting ( IniXMLDocument, "server", "centralservaddr" );
+#ifdef HEADLESS
+        bool bUseGUI = false;
+#else
+        bool bUseGUI = !CommandLineOptions.contains ( "--nogui" );
+#endif
+        // per definition: if we are in "GUI" server mode and no central server
+        // address is given, we use the default central server address
+        if ( bUseGUI && strCentralServer.isEmpty() )
+        {
+            strCentralServer = DEFAULT_SERVER_ADDRESS;
+        }
         // central server address (to be set after the "use default central
         // server address)
-        pServer->SetServerListCentralServerAddress (
-            GetIniSetting ( IniXMLDocument, "server", "centralservaddr" ) );
+        pServer->SetServerListCentralServerAddress ( strCentralServer );
     }
 
     // server list enabled flag

--- a/src/settings.h
+++ b/src/settings.h
@@ -54,8 +54,11 @@ public:
     void Save();
 
     // common settings
-    QByteArray vecWindowPosMain;
-    QString    strLanguage;
+    QByteArray   vecWindowPosMain;
+    QString      strLanguage;
+    EUTCheckType eUTDailyUpdateCheckType;
+    QDateTime    dtUTLastCheck;
+    QString      strUTLastSkippedVersion;
 
 protected:
     virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument ) = 0;
@@ -124,6 +127,8 @@ protected:
                          const QString& sValue = "" );
 
     QString strFileName;
+    QString base64DefaultLastCheck = ToBase64 ( QString ( "1970-01-01T00:00:00Z" ) );
+    QString base64DefaultLastSkippedVersion = ToBase64 ( QString ( "0.0.0" ) );
 
 public slots:
     void OnAboutToQuit() { Save(); }

--- a/src/settings.h
+++ b/src/settings.h
@@ -127,7 +127,6 @@ protected:
 
 public slots:
     void OnAboutToQuit() { Save(); }
-
 };
 
 

--- a/src/updatetool.cpp
+++ b/src/updatetool.cpp
@@ -1,0 +1,591 @@
+/******************************************************************************\
+ * Copyright (c) 2020
+ *
+ * Author(s):
+ *  pljones
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ *
+\******************************************************************************/
+
+#include "updatetool.h"
+
+/*
+ * Things not in "release v1"
+ * * New Client Settings panel entry in Misc: checkbox "Check for update daily" (same setting as the one on the pop up)
+ * * New Server Settings panel entry in Other: checkbox "Check for update daily" (same setting as the one on the pop up)
+ * * Pass clientDlg, serverDlg or nullptr to dailyCheckForUpdates() ?? (not call it CUpdateTool::CUpdateTool)
+ * * Implement time-triggered daily check for no-gui/headless ??? -> dailyCheckForUpdates()
+ */
+
+CUpdateTool::CUpdateTool ( EUTCheckType& eUTCheckType,
+                           QDateTime&    dtUTLastCheck,
+                           QString&      strUTLastSkippedVersion,
+                           const bool&   bUseGUI ) :
+    eCheckType            ( eUTCheckType ),
+    dtLastCheck           ( dtUTLastCheck ),
+    strLastSkippedVersion ( strUTLastSkippedVersion ),
+    bUseGUI               ( bUseGUI )
+{
+    dailyCheckForUpdates();
+}
+
+bool CUpdateTool::isDailyUpdateEnabled ( QWidget* parent )
+{
+    switch ( eCheckType )
+    {
+    case UT_ASK: break;
+    default:
+        return eCheckType == UT_DAILY;
+    }
+
+    if ( !bHaveAskedThisRun )
+    {
+#ifndef HEADLESS
+        if ( bUseGUI )
+        {
+            bHaveAskedThisRun = true;
+            int result = QMessageBox::question ( parent,
+                strUpdateToolTitle,
+                tr ( "Jamulus can check once per day, on start up, for updates." ) + "<br/>"
+                        "<br/>" + tr ( "Do you want this feature enabled now?" ) + "<br/>"
+                        "<br/>" + tr ( "You can change this setting later if you wish." ),
+                strAskLater,
+                tr ( "Check &Daily" ),
+                tr ( "Check Only On &Request" ),
+                0, 0 );
+
+            eCheckType = static_cast<EUTCheckType>( result );
+        }
+        else
+#endif
+        {
+            tsConsole << "Use --updatetool 'daily' to request daily updates (or 'never' to suppress this message)" << "\n";
+        }
+    }
+
+    return eCheckType == UT_DAILY;
+}
+
+void CUpdateTool::dailyCheckForUpdates()
+{
+    if ( shouldCheckForUpdate ( nullptr ) )
+    {
+#ifndef HEADLESS
+        if ( bUseGUI )
+        {
+            connect ( this, &CUpdateTool::AvailableVersion, &CUpdateTool::onDailyUpdateAvailableVersionGUI );
+        }
+        else
+#endif
+        {
+            connect ( this, &CUpdateTool::AvailableVersion, &CUpdateTool::onDailyUpdateAvailableVersion );
+        }
+        getLatestVersion ( nullptr );
+    }
+}
+
+void CUpdateTool::onCheckForUpdates ( QWidget* parent )
+{
+    // UI item clicked, so skip shouldCheckForUpdate() and get on with it but give more feedback
+    connect ( this, &CUpdateTool::AvailableVersion, &CUpdateTool::onCheckNowAvailableVersionGUI );
+    if ( parent != nullptr )
+    {
+        parent->setCursor ( Qt::WaitCursor );
+    }
+    getLatestVersion ( parent );
+}
+
+void CUpdateTool::onDailyUpdateEnabled ( const bool& isDailyUpdateEnable,
+                                         QWidget*    parent )
+{
+    if ( isDailyUpdateEnable )
+    {
+        eCheckType = UT_DAILY;
+        if ( shouldCheckForUpdate ( parent ) )
+        {
+            onCheckForUpdates ( parent );
+        }
+    }
+    else
+    {
+        eCheckType = UT_NEVER;
+    }
+}
+
+void CUpdateTool::onDailyUpdateAvailableVersion ( const bool&              error,
+                                                  const SAvailableVersion& sAvailableVersion,
+                                                  QWidget* )
+{
+    disconnect ( this, &CUpdateTool::AvailableVersion, this, &CUpdateTool::onDailyUpdateAvailableVersion );
+
+    // Already emitted error to log - silently return
+    if ( error )
+    {
+        return;
+    }
+
+    // Record the check!
+    dtLastCheck = QDateTime::currentDateTimeUtc();
+
+    // daily check matches skipped - silently ignore
+    if ( versionCompare ( strLastSkippedVersion, sAvailableVersion.avVersion ) == 0 )
+    {
+        //tsConsole << "onDailyUpdateAvailableVersion: "
+        //          << sAvailableVersion.avVersion << " matches last skipped version"
+        //          << "\n";
+        return;
+    }
+
+    // version is not newer - silently ignore
+    if ( versionCompare ( strAppVersionComparable, sAvailableVersion.avVersion ) >= 0 )
+    {
+        //tsConsole << "onDailyUpdateAvailableVersion: "
+        //          << sAvailableVersion.avVersion << " is not newer than " << APP_VERSION
+        //          << "\n";
+        return;
+    }
+
+    // log the available version details
+    tsConsole << "*** " << strUpdateToolTitle
+              << "\n    " << strNewVersionAvailable << "."
+              << "\n    " << strCurrentVersionMsg << ": " APP_VERSION
+              << "\n    " << strAvailableVersionMsg << ": " << sAvailableVersion.avVersion
+              << "\n    " << strPublishedAtMsg << sAvailableVersion.avPublishedAt.toString ( Qt::DateFormat::ISODate )
+              << ".\n    " << tr ( "You can download it from" ) << " " << QString ( SOFTWARE_DOWNLOAD_URL )
+              << ".\n    " << tr ( "Details of the changes are available here" )
+              << ": " << QString ( SOFTWARE_CHANGELOG_URL ).replace( "<release>", sAvailableVersion.avName )
+              << ".\n" ;
+}
+
+#ifndef HEADLESS
+void CUpdateTool::onDailyUpdateAvailableVersionGUI ( const bool&              error,
+                                                     const SAvailableVersion& sAvailableVersion,
+                                                     QWidget*                 parent )
+{
+    disconnect ( this, &CUpdateTool::AvailableVersion, this, &CUpdateTool::onDailyUpdateAvailableVersionGUI );
+
+    if ( error )
+    {
+        if ( parent != nullptr )
+        {
+            parent->unsetCursor();
+        }
+        QMessageBox::warning ( parent, strUpdateToolTitle, strFailedToFetchVersion );
+        return;
+    }
+
+    // daily check matches skipped - silently ignore
+    if ( versionCompare ( strLastSkippedVersion, sAvailableVersion.avVersion ) == 0 )
+    {
+        //tsConsole << "onDailyUpdateAvailableVersion: "
+        //          << sAvailableVersion.avVersion << " matches last skipped version"
+        //          << "\n";
+        return;
+    }
+
+    // version is not newer - silently ignore
+    if ( versionCompare ( strAppVersionComparable, sAvailableVersion.avVersion ) >= 0 )
+    {
+        //tsConsole << "onDailyUpdateAvailableVersion: "
+        //          << sAvailableVersion.avVersion << " is not newer than " APP_VERSION
+        //          << "\n";
+        return;
+    }
+
+    connect ( this, &CUpdateTool::ChangeLog, &CUpdateTool::onChangeLogGUI );
+    getChangeLog ( sAvailableVersion, parent );
+}
+
+void CUpdateTool::onCheckNowAvailableVersionGUI ( const bool&                           error,
+                                                  const CUpdateTool::SAvailableVersion& sAvailableVersion,
+                                                  QWidget*                              parent )
+{
+    disconnect ( this, &CUpdateTool::AvailableVersion, this, &CUpdateTool::onCheckNowAvailableVersionGUI );
+
+    if ( error )
+    {
+        if ( parent != nullptr )
+        {
+            parent->unsetCursor();
+        }
+        QMessageBox::warning ( parent, strUpdateToolTitle, strFailedToFetchVersion );
+        return;
+    }
+
+    // if version was previously skipped and user now checks, we carry on
+    if (  versionCompare ( strLastSkippedVersion, sAvailableVersion.avVersion ) != 0
+       && versionCompare ( strAppVersionComparable, sAvailableVersion.avVersion ) <= 0 )
+    {
+        if ( parent != nullptr )
+        {
+            parent->unsetCursor();
+        }
+        QMessageBox::information ( parent, strUpdateToolTitle, tr ( "You have the latest released version." ) );
+        return;
+    }
+
+    connect ( this, &CUpdateTool::ChangeLog, &CUpdateTool::onChangeLogGUI );
+    getChangeLog ( sAvailableVersion, parent );
+}
+
+void CUpdateTool::onChangeLogGUI ( const bool& error, const SAvailableVersion& sAvailableVersion, const QStringList& changeLog, QWidget* parent )
+{
+    disconnect ( this, &CUpdateTool::ChangeLog, this, &CUpdateTool::onChangeLogGUI );
+
+    if ( parent != nullptr )
+    {
+        parent->unsetCursor();
+    }
+
+    if ( error )
+    {
+        QMessageBox::warning ( nullptr, strUpdateToolTitle, strFailedToFetchChangeLog + " " + sAvailableVersion.avVersion );
+        return;
+    }
+
+    QMessageBox mbAvailableVersion ( QMessageBox::Question,
+                                     strUpdateToolTitle,
+                                     strNewVersionAvailable );
+    mbAvailableVersion.setInformativeText ( "<br/><strong>" + strCurrentVersionMsg + ":</strong> "  APP_VERSION
+                                          + "<br/><strong>" + strAvailableVersionMsg + ":</strong> " + sAvailableVersion.avVersion
+                                          + "<br/><strong>" + strPublishedAtMsg + ":</strong> " + QLocale().toString ( sAvailableVersion.avPublishedAt )
+                                          + ( strLastSkippedVersion == sAvailableVersion.avVersion
+                                              ? "<br/><br/>" + tr ( "You had previously skipped this version" ) + "."
+                                              : "" )
+                                          );
+    mbAvailableVersion.setDetailedText ( changeLog.join( "\n\n" ) );
+
+    QCheckBox ckbCheckDaily ( strCheckDailyBtn );
+    ckbCheckDaily.setCheckable ( true );
+    ckbCheckDaily.setChecked ( eCheckType == EUTCheckType::UT_DAILY );
+    mbAvailableVersion.setCheckBox ( &ckbCheckDaily );
+
+    QPushButton* btnGo = mbAvailableVersion.addButton ( tr ( "Go To &Download Site" ), QMessageBox::ButtonRole::ActionRole );
+    QPushButton* btnLater = mbAvailableVersion.addButton ( strAskLater, QMessageBox::ButtonRole::RejectRole );
+    QPushButton* btnIgnore = mbAvailableVersion.addButton ( tr ( "I&gnore This Version" ), QMessageBox::ButtonRole::AcceptRole );
+
+    if ( strLastSkippedVersion == sAvailableVersion.avVersion )
+    {
+        mbAvailableVersion.setDefaultButton ( btnIgnore );
+    }
+    else
+    {
+        mbAvailableVersion.setDefaultButton ( btnLater );
+    }
+
+    mbAvailableVersion.setEscapeButton ( btnLater );
+
+    mbAvailableVersion.exec();
+
+    if ( mbAvailableVersion.checkBox()->isChecked() )
+    {
+        eCheckType = EUTCheckType::UT_DAILY;
+    }
+    else if ( eCheckType == EUTCheckType::UT_DAILY )
+    {
+        eCheckType = EUTCheckType::UT_NEVER;
+    }
+
+    if ( btnLater != mbAvailableVersion.clickedButton() )
+    {
+        // Record the check!
+        dtLastCheck = QDateTime::currentDateTimeUtc();
+    }
+
+    if ( btnGo == mbAvailableVersion.clickedButton() )
+    {
+        QDesktopServices::openUrl ( QUrl ( SOFTWARE_DOWNLOAD_URL ) );
+    }
+    else if ( btnIgnore == mbAvailableVersion.clickedButton() )
+    {
+        strLastSkippedVersion = sAvailableVersion.avVersion;
+    }
+}
+#endif
+
+bool CUpdateTool::isDailyUpdateThresholdExpired()
+{
+    return dtLastCheck.addDays( 1 ) < QDateTime::currentDateTimeUtc();
+}
+
+bool CUpdateTool::shouldCheckForUpdate ( QWidget* parent )
+{
+    return ( isDailyUpdateEnabled ( parent ) &&
+             isDailyUpdateThresholdExpired() );
+}
+
+/*
+ * This makes the call to https://api.github.com/repos/corrados/jamulus/releases/latest (SOFTWARE_LATEST_RELEASE_URL)
+ * and parses the result
+ */
+void CUpdateTool::getLatestVersion ( QWidget* parent )
+{
+    QUrl changeLogUrl ( QString ( SOFTWARE_LATEST_RELEASE_URL ) );
+
+    QScopedPointer<QNetworkAccessManager> manager ( new QNetworkAccessManager );
+    QNetworkReply *response = manager->get ( QNetworkRequest ( changeLogUrl ) );
+
+    connect ( response, &QNetworkReply::finished, [this, response, parent] {
+        response->deleteLater();
+        response->manager()->deleteLater();
+
+        static QRegularExpression versionPattern ( "^\\D+(?<X>\\d+)\\D+(?<Y>\\d+)\\D+(?<Z>\\d+).*(?<G>git)?$" );
+
+        SAvailableVersion sAvailableVersion;
+        sAvailableVersion.avVersion = "0.0.0";
+        sAvailableVersion.avPublishedAt = QDateTime::fromString ( "1970-01-01T00:00:00", Qt::ISODate );
+        bool error = true;
+
+        if ( response->error() != QNetworkReply::NoError )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << tr ( "Failed to retrieve version details" ) << ". (" SOFTWARE_LATEST_RELEASE_URL ")"
+                      << "\n" << "Network error:" << response->errorString()
+                      << "\n";
+            emit AvailableVersion ( error, sAvailableVersion, parent );
+            return;
+        }
+
+        QByteArray result = response->readAll();
+        QJsonDocument jsonResponse = QJsonDocument::fromJson ( result );
+
+        QJsonObject obj = jsonResponse.object();
+        if ( !obj["name"].isString() )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << tr ( "JSON response missing expected 'name' property" ) << ". (" SOFTWARE_LATEST_RELEASE_URL ")"
+                      << "\n";
+            emit AvailableVersion ( error, sAvailableVersion, parent );
+            return;
+        }
+        if ( !obj["published_at"].isString() )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << tr ( "JSON response missing expected 'published_at' property" ) << ". (" SOFTWARE_LATEST_RELEASE_URL ")"
+                      << "\n";
+            emit AvailableVersion ( error, sAvailableVersion, parent );
+            return;
+        }
+
+        const QString name = obj["name"].toString();
+        const auto versionMatch = versionPattern.match ( name );
+
+        if ( !versionMatch.hasMatch() || versionMatch.lastCapturedIndex() <= 0 )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << tr ( "Release name is not valid" ) << ": " << name << ". (" SOFTWARE_LATEST_RELEASE_URL ")"
+                      << "\n";
+            emit AvailableVersion ( error, sAvailableVersion, parent );
+            return;
+        }
+        if ( !QDateTime::fromString ( obj["published_at"].toString(), Qt::ISODate ).isValid() )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << tr ( "Publication date is not valid" ) << ": " << obj["published_at"].toString() << ". (" SOFTWARE_LATEST_RELEASE_URL ")"
+                      << "\n";
+            emit AvailableVersion ( error, sAvailableVersion, parent );
+            return;
+        }
+        if ( "git" == versionMatch.captured ( "G" ) && !QString ( APP_VERSION ).endsWith ( "git" ) )
+        {
+            tsConsole << strUpdateToolTitle << " - "
+                      << tr ( "Release name is a git build - ignoring" ) << ": " << name
+                      << "\n";
+            emit AvailableVersion ( false, sAvailableVersion, parent );
+            return;
+        }
+
+        const QString version = versionMatch.captured ( "X" ) + "." + versionMatch.captured ( "Y" ) + "." + versionMatch.captured ( "Z" )
+                + ( "git" == versionMatch.captured ( "G" ) ? ".1" : "" );
+        const QDateTime publishedAt = QDateTime::fromString ( obj["published_at"].toString(), Qt::ISODate );
+
+        sAvailableVersion.avName = name;
+        sAvailableVersion.avVersion = version;
+        sAvailableVersion.avPublishedAt = publishedAt;
+        error = false;
+
+        emit AvailableVersion ( error, sAvailableVersion, parent );
+
+    } ) && manager.take();
+}
+
+int CUpdateTool::versionCompare ( const QString& fromVersion,
+                                  const QString& toVersion )
+{
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
+    // returns -2 if either fromVersion or toVersion is invalid
+    int x1, y1, z1;
+    int x2, y2, z2;
+
+    // validate and parse the versions X.Y.Z
+    if ( !toXYZ ( fromVersion, &x1, &y1, &z1 ) ||
+         !toXYZ ( toVersion, &x2, &y2, &z2 ) )
+    {
+        return -2;
+    }
+    int cmp = x1.compareTo ( x2 );
+    if ( cmp == 0 )
+    {
+        cmp = y1.compareTo ( y2 );
+        if ( cmp == 0 )
+        {
+            return z1.compareTo ( z2 );
+        }
+    }
+    return cmp;
+#else
+    QVersionNumber vnFrom = QVersionNumber::fromString ( fromVersion );
+    QVersionNumber vnTo = QVersionNumber::fromString ( toVersion );
+    return QVersionNumber::compare ( vnFrom, vnTo );
+#endif
+}
+
+/*
+ * This makes the call to https://raw.githubusercontent.com/corrados/jamulus/<release>/ChangeLog (SOFTWARE_CHANGELOG_URL)
+ * (for the available version) and finds the relevant lines from the result
+ */
+void CUpdateTool::getChangeLog ( const SAvailableVersion& sAvailableVersion, QWidget* parent )
+{
+    // Taken from https://stackoverflow.com/a/24966317/8179873
+
+    QUrl changeLogUrl ( QString ( SOFTWARE_CHANGELOG_URL ).replace( "<release>", sAvailableVersion.avName ) );
+
+    QScopedPointer<QNetworkAccessManager> manager ( new QNetworkAccessManager );
+    QNetworkReply *response = manager->get ( QNetworkRequest( changeLogUrl ) );
+
+    connect ( response, &QNetworkReply::finished, [this, response, sAvailableVersion, parent] {
+
+        response->deleteLater();
+        response->manager()->deleteLater();
+
+        QStringList changeLog;
+
+        if ( response->error() != QNetworkReply::NoError )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << strFailedToFetchChangeLog << " " << APP_NAME << " " << sAvailableVersion.avVersion
+                      << "\n    " << strNetworkError << ": " << response->errorString()
+                      << "\n";
+            QMessageBox::warning ( nullptr,
+                                   strUpdateToolTitle,
+                                   strNetworkError + "<br/>" + response->errorString() );
+            emit ChangeLog ( true, sAvailableVersion, changeLog, parent );
+            return;
+        }
+
+        const QString contentType = response->header ( QNetworkRequest::ContentTypeHeader ).toString();
+        static QRegularExpression contentTypeCharsetPattern ( "charset=([!-~]+)" );
+        auto const charsetMatch = contentTypeCharsetPattern.match ( contentType );
+        if ( !charsetMatch.hasMatch() || 0 != charsetMatch.captured ( 1 ).compare ( "utf-8", Qt::CaseInsensitive ) )
+        {
+            tsConsole << "!!! "
+                      << strUpdateToolTitle << " - "
+                      << tr ( "Invalid character set (only utf-8 supported)" ) << ": " << contentType << ". (" SOFTWARE_LATEST_RELEASE_URL ")"
+                      << "\n";
+            emit ChangeLog ( true, sAvailableVersion, changeLog, parent );
+            return;
+        }
+
+        QStringList lines = QString::fromUtf8 ( response->readAll() )
+                .split('\n', QString::SplitBehavior::SkipEmptyParts);
+
+        // Matcher for "X.Y.Z (yyyy-mm-dd)"
+        static QRegularExpression changeLogVersionPattern ( "^(?<XYZ>\\d+\\.\\d+\\.\\d+).*(?<G>git)?\\h+\\((?<DATE>\\d{4}-\\d{2}-\\d{2})\\)\\h*$" );
+        bool seenToVersion = false;
+        while ( lines.size() > 0 )
+        {
+            QString line = lines.takeFirst();
+            auto const versionMatch = changeLogVersionPattern.match ( line );
+            if ( versionMatch.hasMatch() )
+            {
+                QString strLineVersion = versionMatch.captured ( "XYZ" );
+                if ( "git" == versionMatch.captured ( "G" ) )
+                {
+                    strLineVersion += ".1";
+                }
+                if ( versionCompare ( strLineVersion, strAppVersionComparable ) <= 0 )
+                {
+                    break;
+                }
+                if ( versionCompare ( strLineVersion, sAvailableVersion.avVersion ) >= 0 )
+                {
+                    seenToVersion = true;
+                }
+            }
+            if ( seenToVersion )
+            {
+                if ( !line.startsWith( ' ' ) )
+                {
+                    changeLog << line;
+                }
+                else if ( !changeLog.isEmpty() )
+                {
+                    changeLog.last().append ( line.trimmed() );
+                }
+                else
+                {
+                    // throw the line away as it's vertical whitespace
+                }
+            }
+        }
+
+        emit ChangeLog ( false, sAvailableVersion, changeLog, parent );
+
+    } ) && manager.take();
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
+bool CUpdateTool::toInt(const QString& version, int* v)
+{
+    bool ok = true;
+    *v = version.toInt ( &ok );
+    if ( !ok )
+    {
+        *v = -1;
+    }
+    return ok;
+}
+
+bool CUpdateTool::toXYZ(const QString& version, int* x, int* y, int* z)
+{
+    bool ok = true;
+    static QRegularExpression versionPattern ( "^\\D*(\\d+)\\D+(\\d+)\\D+(\\d+)\\D+$" );
+    auto const versionMatch = versionPattern.match ( version );
+    if ( versionMatch.hasMatch() )
+    {
+        ok &= toInt ( versionMatch.captured ( 1 ), x );
+        ok &= toInt ( versionMatch.captured ( 2 ), y );
+        ok &= toInt ( versionMatch.captured ( 3 ), z );
+    }
+    else
+    {
+        ok = false;
+    }
+    if ( !ok )
+    {
+        *x = *y = *z = -1;
+    }
+    return ok;
+}
+#endif

--- a/src/updatetool.h
+++ b/src/updatetool.h
@@ -1,0 +1,119 @@
+/******************************************************************************\
+ * Copyright (c) 2020
+ *
+ * Author(s):
+ *  pljones
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ *
+\******************************************************************************/
+
+#pragma once
+
+#include "QObject"
+#ifndef HEADLESS
+# include <QMessageBox>
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+# include <QVersionNumber>
+#endif
+#include <QDateTime>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkRequest>
+#include <QtNetwork/QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QEventLoop>
+
+#include "global.h"
+#include "util.h"
+
+class CUpdateTool : public QObject
+{
+    Q_OBJECT
+
+    /*
+     * This is used to return the "interesting" part of https://api.github.com/repos/corrados/jamulus/releases/latest
+     */
+    struct SAvailableVersion
+    {
+    public:
+        QString   avName;
+        QString   avVersion;
+        QDateTime avPublishedAt;
+    };
+
+public:
+    CUpdateTool ( EUTCheckType& eUTCheckType, QDateTime& dtUTLastCheck, QString& strUTLastSkippedVersion, const bool& bUseGUI );
+
+    bool isDailyUpdateEnabled ( QWidget* parent = nullptr );
+    void dailyCheckForUpdates();
+
+    QString CheckDailyBtnText() { return strCheckDailyBtn; }
+    QString CheckNowBtnText() { return strCheckNowBtn; }
+
+public slots:
+    void onCheckForUpdates ( QWidget* parent );
+    void onDailyUpdateEnabled ( const bool& isDailyUpdateEnable, QWidget* parent );
+
+signals:
+    void AvailableVersion ( const bool& error, const SAvailableVersion& sAvailableVersion, QWidget* parent );
+    void ChangeLog ( const bool& error, const SAvailableVersion& sAvailableVersion, const QStringList& changeLog, QWidget* parent );
+
+private slots:
+    void onDailyUpdateAvailableVersion (const bool& error, const SAvailableVersion& sAvailableVersion, QWidget* );
+#ifndef HEADLESS
+    void onDailyUpdateAvailableVersionGUI ( const bool& error, const SAvailableVersion& sAvailableVersion, QWidget* parent );
+    void onCheckNowAvailableVersionGUI ( const bool& error, const SAvailableVersion& sAvailableVersion, QWidget* parent );
+    void onChangeLogGUI ( const bool& error, const SAvailableVersion& sAvailableVersion, const QStringList& changeLog, QWidget* parent );
+#endif
+
+private:
+    EUTCheckType& eCheckType;
+    QDateTime& dtLastCheck;
+    QString& strLastSkippedVersion;
+    const bool bUseGUI;
+
+    bool bHaveAskedThisRun;
+    QString strAppVersionComparable = QString ( APP_VERSION ).replace ( "git", ".1" );
+
+    // Re-used messages
+    QString strUpdateToolTitle = tr ( APP_NAME " Update Tool" );
+    QString strAskLater = tr ( "&Ask Later" );
+    QString strNetworkError = tr ( "Network Error" );
+    QString strFetchingVersion = tr ( "Fetching latest version information" ) + "...";
+    QString strFailedToFetchVersion = tr ( "Failed to retrieve version details" );
+    QString strNewVersionAvailable = tr ( "A new version of " APP_NAME " is available" ) + ".";
+    QString strCurrentVersionMsg = tr ( "Current Version" );
+    QString strAvailableVersionMsg = tr ( "Available Version" );
+    QString strPublishedAtMsg = tr ( "Date published" );
+    QString strCheckDailyBtn = tr ( "Check &Daily For Updates" );
+    QString strCheckNowBtn = tr ( "Check For &Update Now" );
+    QString strFailedToFetchChangeLog = tr ( "Failed to retrieve change log for" );
+
+    bool isDailyUpdateThresholdExpired();
+    bool shouldCheckForUpdate ( QWidget* parent );
+    void getLatestVersion ( QWidget* parent );
+    static int versionCompare ( const QString& fromVersion, const QString& toVersion );
+    void getChangeLog ( const SAvailableVersion& sAvailableVersion , QWidget* parent );
+    QTextStream& tsConsole = *( ( new ConsoleWriterFactory() )->get() );
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
+    static bool toInt ( const QString& version, int* v );
+    static bool toXYZ ( const QString& version, int* x, int* y, int* z );
+#endif
+};

--- a/src/util.h
+++ b/src/util.h
@@ -66,6 +66,7 @@ using namespace std; // because of the library: "vector"
 
 
 class CClient;  // forward declaration of CClient
+class CUpdateTool; // forward declaration of CUpdateTool
 
 
 /* Definitions ****************************************************************/
@@ -421,8 +422,10 @@ class CAboutDlg : public QDialog, private Ui_CAboutDlgBase
 {
     Q_OBJECT
 
+    CUpdateTool* UpdateTool;
+
 public:
-    CAboutDlg ( QWidget* parent = nullptr );
+    CAboutDlg ( CUpdateTool* updateTool, QWidget* parent = nullptr );
 };
 
 
@@ -477,10 +480,11 @@ class CHelpMenu : public QMenu
     Q_OBJECT
 
 public:
-    CHelpMenu ( const bool bIsClient, QWidget* parent = nullptr );
+    CHelpMenu ( const bool bIsClient, CUpdateTool* updateTool, QWidget* parent = nullptr );
 
 protected:
-    CAboutDlg AboutDlg;
+    CAboutDlg    AboutDlg;
+    CUpdateTool* UpdateTool;
 
 public slots:
     void OnHelpWhatsThis()        { QWhatsThis::enterWhatsThisMode(); }
@@ -730,6 +734,20 @@ enum ESkillLevel
 #define RGBCOL_R_SL_SL_PROFESSIONAL 255
 #define RGBCOL_G_SL_SL_PROFESSIONAL 225
 #define RGBCOL_B_SL_SL_PROFESSIONAL 225
+
+
+// Daily Update check enum -----------------------------------------------------
+/*
+ * This is used for the value returned from the settings:
+ * "Ask" == "unset": ask the user what they want (if not headless)
+ * "Daily" == "enable": check for updates automatically once a day on start up
+ * "Never" == "disable": do not check automatically
+ */
+enum EUTCheckType {
+    UT_ASK = 0,
+    UT_DAILY = 1,
+    UT_NEVER = 2
+};
 
 
 // Stereo signal level meter ---------------------------------------------------


### PR DESCRIPTION
Whilst I was doing the update checker, I couldn't stop myself making a few other small changes:
* Mention use of "-e localhost"
* Move saving settings to CSettings
* Move defaulting of centralserver into CSettings
* Server translations might be used even headless (logging)

The bulk of the changes is in the one commit.  It relies on the change to make CSettings responsible for saving and I used `tr()` liberally, even headless, so loading the translations might be useful.  The other two were very much "in passing" - the first triggered by some comment on Facebook, the third following my other changes (should have been done there).  Anyway...
* Add an update checker