### PR TITLE
Load settings even without gui

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -630,16 +630,16 @@ int main ( int argc, char** argv )
             CClientSettings Settings ( &Client, strIniFileName );
             Settings.Load ( CommandLineOptions );
 
-            // load translation
-            if ( bUseGUI && bUseTranslation )
-            {
-                CLocale::LoadTranslation ( Settings.strLanguage, pApp );
-                CInstPictures::UpdateTableOnLanguageChange();
-            }
-
 #ifndef HEADLESS
             if ( bUseGUI )
             {
+                // load translation
+                if ( bUseTranslation )
+                {
+                    CLocale::LoadTranslation ( Settings.strLanguage, pApp );
+                    CInstPictures::UpdateTableOnLanguageChange();
+                }
+
                 // GUI object
                 CClientDlg ClientDlg ( &Client,
                                        &Settings,
@@ -684,15 +684,15 @@ int main ( int argc, char** argv )
                              bUseMultithreading,
                              eLicenceType );
 
+            // load settings from init-file (command line options override)
+            CServerSettings Settings ( &Server, strIniFileName );
+            Settings.Load ( CommandLineOptions );
+
 #ifndef HEADLESS
             if ( bUseGUI )
             {
-                // load settings from init-file (command line options override)
-                CServerSettings Settings ( &Server, strIniFileName );
-                Settings.Load ( CommandLineOptions );
-
                 // load translation
-                if ( bUseGUI && bUseTranslation )
+                if ( bUseTranslation )
                 {
                     CLocale::LoadTranslation ( Settings.strLanguage, pApp );
                 }


### PR DESCRIPTION
Two minor changes:

In the _client_ side, there's a check for `bUseGUI && bUseTranslation` _immediately_ before a check for `bUseGUI`.   I've just moved the code inside the later `if`.

Now, that code is _after_ the client inifile load on line 631 - the client _always_ loads the inifile, headless, nogui, whatever.

So, the second change is a little bigger in effect, although the code looks smaller (side by side diff).  Line 695 was _already_ inside a check for `bUseGUI`, so drop the duplication.  Then move the inifile load outside the `#ifndef` to match the client.