### PR TITLE
Feature/default centralserver in settings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -547,13 +547,6 @@ int main ( int argc, char** argv )
 
 
     // Dependencies ------------------------------------------------------------
-    // per definition: if we are in "GUI" server mode and no central server
-    // address is given, we use the default central server address
-    if ( !bIsClient && bUseGUI && strCentralServer.isEmpty() )
-    {
-        strCentralServer = DEFAULT_SERVER_ADDRESS;
-    }
-
     // adjust default port number for client: use different default port than the server since
     // if the client is started before the server, the server would get a socket bind error
     if ( bIsClient && !bCustomPortNumberGiven )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -630,16 +630,16 @@ int main ( int argc, char** argv )
             CClientSettings Settings ( &Client, strIniFileName );
             Settings.Load ( CommandLineOptions );
 
-            // load translation
-            if ( bUseGUI && bUseTranslation )
-            {
-                CLocale::LoadTranslation ( Settings.strLanguage, pApp );
-                CInstPictures::UpdateTableOnLanguageChange();
-            }
-
 #ifndef HEADLESS
             if ( bUseGUI )
             {
+                // load translation
+                if ( bUseTranslation )
+                {
+                    CLocale::LoadTranslation ( Settings.strLanguage, pApp );
+                    CInstPictures::UpdateTableOnLanguageChange();
+                }
+
                 // GUI object
                 CClientDlg ClientDlg ( &Client,
                                        &Settings,
@@ -684,15 +684,15 @@ int main ( int argc, char** argv )
                              bUseMultithreading,
                              eLicenceType );
 
+            // load settings from init-file (command line options override)
+            CServerSettings Settings ( &Server, strIniFileName );
+            Settings.Load ( CommandLineOptions );
+
 #ifndef HEADLESS
             if ( bUseGUI )
             {
-                // load settings from init-file (command line options override)
-                CServerSettings Settings ( &Server, strIniFileName );
-                Settings.Load ( CommandLineOptions );
-
                 // load translation
-                if ( bUseGUI && bUseTranslation )
+                if ( bUseTranslation )
                 {
                     CLocale::LoadTranslation ( Settings.strLanguage, pApp );
                 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -812,10 +812,18 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
 
     if ( !CommandLineOptions.contains ( "--centralserver" ) )
     {
+        QString strCentralServer = GetIniSetting ( IniXMLDocument, "server", "centralservaddr" );
+#ifndef HEADLESS
+        // per definition: if we are in "GUI" server mode and no central server
+        // address is given, we use the default central server address
+        if ( strCentralServer.isEmpty() && !CommandLineOptions.contains ( "--nogui" ) )
+        {
+            strCentralServer = DEFAULT_SERVER_ADDRESS;
+        }
+#endif
         // central server address (to be set after the "use default central
         // server address)
-        pServer->SetServerListCentralServerAddress (
-            GetIniSetting ( IniXMLDocument, "server", "centralservaddr" ) );
+        pServer->SetServerListCentralServerAddress ( strCentralServer );
     }
 
     // server list enabled flag


### PR DESCRIPTION
So, given we're now always calling the server side inifile loader, headless, nogui, whatever - just like the client.

That means the handling of the central server setting can be moved into CSettings.  `main.cpp` just collects command line settings and passes responsibility to CSettings to sort out any subsequent worries.

Note that the diff is against _current_ master, so includes 0217037 .  If that gets merged first, this should remain valid, I think...

(Hm.  Weird.  For some reason git's decided you made these changes...)