### PR TITLE
update d/rules (workaround issue in desktop file)

### DIFF
--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -15,8 +15,8 @@ override_dh_auto_build:
 	cd build-nox && make
 
 override_dh_auto_install:
-	cd build-gui && make install INSTALL_ROOT=../debian/tmp
 	cd build-nox && make install INSTALL_ROOT=../debian/tmp
+	cd build-gui && make install INSTALL_ROOT=../debian/tmp
 
 override_dh_auto_clean:
 	rm -rf build-gui


### PR DESCRIPTION
The `exec` field is replaced with jamulus-headless which isn't what's expected by the user to be executed.

Pinging @tormodvolden since you've been working on the debian/ files recently.

@corrados : maybe it could be a good idea to generate a desktop file for jamulus-GUI ("jamulus.desktop") and another desktop file for jamulus-headless ("jamulus-headless.desktop").