### PR TITLE
Split messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@
 
 - added a command line argument to enable multithreading in the server (#339)
 
+- added support for split protocol messages (fixes bug with large number of clients
+  connected to a server, #547)
+
 - store recorder settings, coded by pljones (#313)
 
 - accessibility improvements, coded by chigkim (#498, #512)

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -104,6 +104,12 @@ qRegisterMetaType<CHostAddress> ( "CHostAddress" );
     QObject::connect ( &Protocol, &CProtocol::ReqNetTranspProps,
         this, &CChannel::OnReqNetTranspProps );
 
+    QObject::connect ( &Protocol, &CProtocol::ReqSplitMessSupport,
+        this, &CChannel::OnReqSplitMessSupport );
+
+    QObject::connect ( &Protocol, &CProtocol::SplitMessSupported,
+        this, &CChannel::OnSplitMessSupported );
+
     QObject::connect ( &Protocol, &CProtocol::LicenceRequired,
         this, &CChannel::LicenceRequired );
 
@@ -470,6 +476,13 @@ void CChannel::OnReqNetTranspProps()
     Protocol.CreateNetwTranspPropsMes ( GetNetworkTransportPropsFromCurrentSettings() );
 }
 
+void CChannel::OnReqSplitMessSupport()
+{
+    // activate split messages in our protocol (client) and return answer message to the server
+    Protocol.SetSplitMessageSupported ( true );
+    Protocol.CreateSplitMessSupportedMes();
+}
+
 CNetworkTransportProps CChannel::GetNetworkTransportPropsFromCurrentSettings()
 {
     // use current stored settings of the channel to fill the network transport
@@ -641,6 +654,9 @@ EGetDataStat CChannel::GetData ( CVector<uint8_t>& vecbyData,
     // in case we are just disconnected, we have to fire a message
     if ( eGetStatus == GS_CHAN_NOW_DISCONNECTED )
     {
+        // reset the protocol
+        Protocol.Reset();
+
         // emit message
         emit Disconnected();
     }

--- a/src/channel.h
+++ b/src/channel.h
@@ -159,6 +159,7 @@ public:
     }
     void CreateClientIDMes ( const int iChanID )             { Protocol.CreateClientIDMes ( iChanID ); }
     void CreateReqNetwTranspPropsMes()                       { Protocol.CreateReqNetwTranspPropsMes(); }
+    void CreateReqSplitMessSupportMes()                      { Protocol.CreateReqSplitMessSupportMes(); }
     void CreateReqJitBufMes()                                { Protocol.CreateReqJitBufMes(); }
     void CreateReqConnClientsList()                          { Protocol.CreateReqConnClientsList(); }
     void CreateChatTextMes ( const QString& strChatText )    { Protocol.CreateChatTextMes ( strChatText ); }
@@ -245,6 +246,8 @@ public slots:
     void OnChangeChanInfo ( CChannelCoreInfo ChanInfo );
     void OnNetTranspPropsReceived ( CNetworkTransportProps NetworkTransportProps );
     void OnReqNetTranspProps();
+    void OnReqSplitMessSupport();
+    void OnSplitMessSupported() { Protocol.SetSplitMessageSupported ( true ); }
 
     void OnParseMessageBody ( CVector<uint8_t> vecbyMesBodyData,
                               int              iRecCounter,

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -853,96 +853,82 @@ qDebug() << "iRecIDModified: " << iRecIDModified << ", vecbyMesBodyDataModified.
     }
 }
 
-bool CProtocol::ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMesBodyData,
+void CProtocol::ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMesBodyData,
                                                  const int               iRecID,
                                                  const CHostAddress&     InetAddr )
 {
-/*
-    return code: false -> ok; true -> error
-*/
-    bool bRet = false;
-
 /*
 // TEST channel implementation: randomly delete protocol messages (50 % loss)
 if ( rand() < ( RAND_MAX / 2 ) ) return false;
 */
 
-    if ( IsConnectionLessMessageID ( iRecID ) )
+    // check which type of message we received and do action
+    switch ( iRecID )
     {
-        // check which type of message we received and do action
-        switch ( iRecID )
-        {
-        case PROTMESSID_CLM_PING_MS:
-            bRet = EvaluateCLPingMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_PING_MS:
+        EvaluateCLPingMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_PING_MS_WITHNUMCLIENTS:
-            bRet = EvaluateCLPingWithNumClientsMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_PING_MS_WITHNUMCLIENTS:
+        EvaluateCLPingWithNumClientsMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_SERVER_FULL:
-            bRet = EvaluateCLServerFullMes();
-            break;
+    case PROTMESSID_CLM_SERVER_FULL:
+        EvaluateCLServerFullMes();
+        break;
 
-        case PROTMESSID_CLM_SERVER_LIST:
-            bRet = EvaluateCLServerListMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_SERVER_LIST:
+        EvaluateCLServerListMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_REQ_SERVER_LIST:
-            bRet = EvaluateCLReqServerListMes ( InetAddr );
-            break;
+    case PROTMESSID_CLM_REQ_SERVER_LIST:
+        EvaluateCLReqServerListMes ( InetAddr );
+        break;
 
-        case PROTMESSID_CLM_SEND_EMPTY_MESSAGE:
-            bRet = EvaluateCLSendEmptyMesMes ( vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_SEND_EMPTY_MESSAGE:
+        EvaluateCLSendEmptyMesMes ( vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_REGISTER_SERVER:
-            bRet = EvaluateCLRegisterServerMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_REGISTER_SERVER:
+        EvaluateCLRegisterServerMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_REGISTER_SERVER_EX:
-            bRet = EvaluateCLRegisterServerExMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_REGISTER_SERVER_EX:
+        EvaluateCLRegisterServerExMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_UNREGISTER_SERVER:
-            bRet = EvaluateCLUnregisterServerMes ( InetAddr );
-            break;
+    case PROTMESSID_CLM_UNREGISTER_SERVER:
+        EvaluateCLUnregisterServerMes ( InetAddr );
+        break;
 
-        case PROTMESSID_CLM_DISCONNECTION:
-            bRet = EvaluateCLDisconnectionMes ( InetAddr );
-            break;
+    case PROTMESSID_CLM_DISCONNECTION:
+        EvaluateCLDisconnectionMes ( InetAddr );
+        break;
 
-        case PROTMESSID_CLM_VERSION_AND_OS:
-            bRet = EvaluateCLVersionAndOSMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_VERSION_AND_OS:
+        EvaluateCLVersionAndOSMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_REQ_VERSION_AND_OS:
-            bRet = EvaluateCLReqVersionAndOSMes ( InetAddr );
-            break;
+    case PROTMESSID_CLM_REQ_VERSION_AND_OS:
+        EvaluateCLReqVersionAndOSMes ( InetAddr );
+        break;
 
-        case PROTMESSID_CLM_CONN_CLIENTS_LIST:
-            bRet = EvaluateCLConnClientsListMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_CONN_CLIENTS_LIST:
+        EvaluateCLConnClientsListMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_REQ_CONN_CLIENTS_LIST:
-            bRet = EvaluateCLReqConnClientsListMes ( InetAddr );
-            break;
+    case PROTMESSID_CLM_REQ_CONN_CLIENTS_LIST:
+        EvaluateCLReqConnClientsListMes ( InetAddr );
+        break;
 
-        case PROTMESSID_CLM_CHANNEL_LEVEL_LIST:
-            bRet = EvaluateCLChannelLevelListMes ( InetAddr, vecbyMesBodyData );
-            break;
+    case PROTMESSID_CLM_CHANNEL_LEVEL_LIST:
+        EvaluateCLChannelLevelListMes ( InetAddr, vecbyMesBodyData );
+        break;
 
-        case PROTMESSID_CLM_REGISTER_SERVER_RESP:
-            bRet = EvaluateCLRegisterServerResp ( InetAddr, vecbyMesBodyData );
-            break;
-        }
+    case PROTMESSID_CLM_REGISTER_SERVER_RESP:
+        EvaluateCLRegisterServerResp ( InetAddr, vecbyMesBodyData );
+        break;
     }
-    else
-    {
-        bRet = true; // return error code
-    }
-
-    return bRet;
 }
 
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -705,6 +705,9 @@ int              iRecIDModified = iRecID;
                                                    iReceivedNumParts,
                                                    iReceivedSplitCnt ) )
                 {
+
+// TODO put check ( iSplitMessageCnt >= MAX_NUM_MESS_SPLIT_PARTS - 1 ) in front of the ParseSplitMessageContainer call
+
                     // consistency checks
                     if ( ( iSplitMessageCnt != iReceivedSplitCnt ) ||
                          ( iSplitMessageCnt >= iReceivedNumParts ) ||

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -211,7 +211,7 @@ protected:
                                     const int               iSplitCnt,
                                     const CVector<uint8_t>& vecData );
 
-    void ParseSplitMessageContainer ( const CVector<uint8_t>& vecbyData,
+    bool ParseSplitMessageContainer ( const CVector<uint8_t>& vecbyData,
                                       CVector<uint8_t>&       vecbyMesBodyData,
                                       int&                    iID,
                                       int&                    iNumParts,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <QDateTime>
 #include <list>
+#include <cmath>
 #include "global.h"
 #include "util.h"
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -91,6 +91,10 @@
 // time out for message re-send if no acknowledgement was received
 #define SEND_MESS_TIMEOUT_MS            400 // ms
 
+// message split parameters
+#define MESS_SPLIT_PART_SIZE_BYTES      550
+#define MAX_NUM_MESS_SPLIT_PARTS        ( MAX_SIZE_BYTES_NETW_BUF / 600 )
+
 
 /* Classes ********************************************************************/
 class CProtocol : public QObject
@@ -157,7 +161,7 @@ public:
                                     int&                    iRecCounter,
                                     int&                    iRecID );
 
-    bool ParseMessageBody ( const CVector<uint8_t>& vecbyMesBodyData,
+    void ParseMessageBody ( const CVector<uint8_t>& vecbyMesBodyData,
                             const int               iRecCounter,
                             const int               iRecID );
 
@@ -298,9 +302,8 @@ protected:
     QTimer                  TimerSendMess;
     QMutex                  Mutex;
 
-    CVector<CVector<uint8_t> > vecvecbySplitMessageStorage;
-    int                        iSplitMessageCnt;
-    int                        iPartSize;
+    CVector<uint8_t>        vecvecbySplitMessageStorage[MAX_NUM_MESS_SPLIT_PARTS];
+    int                     iSplitMessageCnt;
 
 public slots:
     void OnTimerSendMess() { SendMessage(); }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -224,9 +224,11 @@ protected:
 
     bool ParseSplitMessageContainer ( const CVector<uint8_t>& vecbyData,
                                       CVector<uint8_t>&       vecbyMesBodyData,
+                                      const int               iSplitMessageDataIndex,
                                       int&                    iID,
                                       int&                    iNumParts,
-                                      int&                    iSplitCnt );
+                                      int&                    iSplitCnt,
+                                      int&                    iCurPartSize );
 
     void PutValOnStream ( CVector<uint8_t>& vecIn,
                           int&              iPos,
@@ -311,8 +313,9 @@ protected:
     QTimer                  TimerSendMess;
     QMutex                  Mutex;
 
-    CVector<uint8_t>        vecvecbySplitMessageStorage[MAX_NUM_MESS_SPLIT_PARTS];
+    CVector<uint8_t>        vecbySplitMessageStorage;
     int                     iSplitMessageCnt;
+    int                     iSplitMessageDataIndex;
     bool                    bSplitMessageSupported;
 
 public slots:

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -205,6 +205,12 @@ protected:
                            const int               iID,
                            const CVector<uint8_t>& vecData );
 
+    void GenSplitMessageContainer ( CVector<uint8_t>&       vecOut,
+                                    const int               iID,
+                                    const int               iNumParts,
+                                    const int               iSplitCnt,
+                                    const CVector<uint8_t>& vecData );
+
     void ParseSplitMessageContainer ( const CVector<uint8_t>& vecbyData,
                                       CVector<uint8_t>&       vecbyMesBodyData,
                                       int&                    iID,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -81,6 +81,9 @@
 #define PROTMESSID_CLM_REGISTER_SERVER_RESP   1016 // status of server registration request
 #define PROTMESSID_CLM_REGISTER_SERVER_EX     1017 // register server with extended information
 
+// special IDs
+#define PROTMESSID_SPECIAL_SPLIT_MESSAGE      2001 // a container for split messages
+
 // lengths of message as defined in protocol.cpp file
 #define MESS_HEADER_LENGTH_BYTE         7 // TAG (2), ID (2), cnt (1), length (2)
 #define MESS_LEN_WITHOUT_DATA_BYTE      ( MESS_HEADER_LENGTH_BYTE + 2 /* CRC (2) */ )
@@ -202,6 +205,12 @@ protected:
                            const int               iID,
                            const CVector<uint8_t>& vecData );
 
+    void ParseSplitMessageContainer ( const CVector<uint8_t>& vecbyData,
+                                      CVector<uint8_t>&       vecbyMesBodyData,
+                                      int&                    iID,
+                                      int&                    iNumParts,
+                                      int&                    iSplitCnt );
+
     void PutValOnStream ( CVector<uint8_t>& vecIn,
                           int&              iPos,
                           const uint32_t    iVal,
@@ -282,6 +291,10 @@ protected:
 
     QTimer                  TimerSendMess;
     QMutex                  Mutex;
+
+    CVector<CVector<uint8_t> > vecvecbySplitMessageStorage;
+    int                        iSplitMessageCnt;
+    int                        iPartSize;
 
 public slots:
     void OnTimerSendMess() { SendMessage(); }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -95,7 +95,7 @@
 
 // message split parameters
 #define MESS_SPLIT_PART_SIZE_BYTES      550
-#define MAX_NUM_MESS_SPLIT_PARTS        ( MAX_SIZE_BYTES_NETW_BUF / 600 )
+#define MAX_NUM_MESS_SPLIT_PARTS        ( MAX_SIZE_BYTES_NETW_BUF / MESS_SPLIT_PART_SIZE_BYTES )
 
 
 /* Classes ********************************************************************/

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -165,7 +165,7 @@ public:
                             const int               iRecCounter,
                             const int               iRecID );
 
-    bool ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMesBodyData,
+    void ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMesBodyData,
                                           const int               iRecID,
                                           const CHostAddress&     InetAddr );
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -218,7 +218,9 @@ protected:
                                     const int               iID,
                                     const int               iNumParts,
                                     const int               iSplitCnt,
-                                    const CVector<uint8_t>& vecData );
+                                    const CVector<uint8_t>& vecData,
+                                    const int               iStartIndexInData,
+                                    const int               iLengthOfDataPart );
 
     bool ParseSplitMessageContainer ( const CVector<uint8_t>& vecbyData,
                                       CVector<uint8_t>&       vecbyMesBodyData,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -60,6 +60,8 @@
 #define PROTMESSID_MUTE_STATE_CHANGED         31 // mute state of your signal at another client has changed
 #define PROTMESSID_CLIENT_ID                  32 // current user ID and server status
 #define PROTMESSID_RECORDER_STATE             33 // contains the state of the jam recorder (ERecorderState)
+#define PROTMESSID_REQ_SPLIT_MESS_SUPPORT     34 // request support for split messages
+#define PROTMESSID_SPLIT_MESS_SUPPORTED       35 // split messages are supported
 
 // message IDs of connection less messages (CLM)
 // DEFINITION -> start at 1000, end at 1999, see IsConnectionLessMessageID
@@ -105,6 +107,7 @@ public:
     CProtocol();
 
     void Reset();
+    void SetSplitMessageSupported ( const bool bIn ) { bSplitMessageSupported = bIn; }
 
     void CreateJitBufMes ( const int iJitBufSize );
     void CreateReqJitBufMes();
@@ -119,6 +122,8 @@ public:
     void CreateChatTextMes ( const QString strChatText );
     void CreateNetwTranspPropsMes ( const CNetworkTransportProps& NetTrProps );
     void CreateReqNetwTranspPropsMes();
+    void CreateReqSplitMessSupportMes();
+    void CreateSplitMessSupportedMes();
     void CreateLicenceRequiredMes ( const ELicenceType eLicenceType );
     void CreateOpusSupportedMes();
     void CreateReqChannelLevelListMes ( const bool bRCL );
@@ -261,6 +266,8 @@ protected:
     bool EvaluateChatTextMes            ( const CVector<uint8_t>& vecData );
     bool EvaluateNetwTranspPropsMes     ( const CVector<uint8_t>& vecData );
     bool EvaluateReqNetwTranspPropsMes();
+    bool EvaluateReqSplitMessSupportMes();
+    bool EvaluateSplitMessSupportedMes();
     bool EvaluateLicenceRequiredMes     ( const CVector<uint8_t>& vecData );
     bool EvaluateReqChannelLevelListMes ( const CVector<uint8_t>& vecData );
     bool EvaluateVersionAndOSMes        ( const CVector<uint8_t>& vecData );
@@ -304,6 +311,7 @@ protected:
 
     CVector<uint8_t>        vecvecbySplitMessageStorage[MAX_NUM_MESS_SPLIT_PARTS];
     int                     iSplitMessageCnt;
+    bool                    bSplitMessageSupported;
 
 public slots:
     void OnTimerSendMess() { SendMessage(); }
@@ -330,6 +338,8 @@ signals:
     void ChatTextReceived ( QString strChatText );
     void NetTranspPropsReceived ( CNetworkTransportProps NetworkTransportProps );
     void ReqNetTranspProps();
+    void ReqSplitMessSupport();
+    void SplitMessSupported();
     void LicenceRequired ( ELicenceType eLicenceType );
     void ReqChannelLevelList ( bool bOptIn );
     void VersionAndOSReceived ( COSUtil::EOpSystemType eOSType, QString strVersion );

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -596,6 +596,9 @@ void CServer::OnNewConnection ( int          iChID,
     // must be the first message to be sent for a new connection)
     vecChannels[iChID].CreateClientIDMes ( iChID );
 
+    // query support for split messages in the client
+    vecChannels[iChID].CreateReqSplitMessSupportMes();
+
     // on a new connection we query the network transport properties for the
     // audio packets (to use the correct network block size and audio
     // compression properties, etc.)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1680,7 +1680,7 @@ bool CServer::CreateLevelsForAllConChannels ( const int                        i
                                               vecNumAudioChannels[j] > 1 );
 
             // map value to integer for transmission via the protocol (4 bit available)
-            vecLevelsOut[j] = static_cast<uint16_t> ( ceil ( dCurSigLevelForMeterdB ) );
+            vecLevelsOut[j] = static_cast<uint16_t> ( std::ceil ( dCurSigLevelForMeterdB ) );
         }
     }
 


### PR DESCRIPTION
Large Jamulus protocol messages may hit a limit where UDP packets are blocked by some fragmentation issues (see https://github.com/corrados/jamulus/issues/255). Recently, when a lot of clients are connected to the server, we do not only see this UDP blocking issue for the server list but also at normal operation of Jamulus (i.e. the procol mechanism gets stuck), see https://github.com/corrados/jamulus/issues/547.

Since the protocol stack in Jamulus is a very critical part regarding stability and security:

@softins Since you are the wireshark/protocol expert, could you please review the code to make sure it works correctly, does not break compatibility and does not crash.

@atsampson I saw that you have done a lot of stability/fuzzing testing for the Issue https://github.com/corrados/jamulus/issues/314. Since with this new code a lot of the protocol mechanism is changed, I may have introduced new security issues. Could you please review the code and/or test the new code with your fuzzing tools to make sure it still is stable and secure?