### PR TITLE
#606 Persist state of recorder

### DIFF
--- a/src/recorder/jamcontroller.cpp
+++ b/src/recorder/jamcontroller.cpp
@@ -48,15 +48,20 @@ void CJamController::SetEnableRecording  ( bool bNewEnableRecording, bool isRunn
 
     if ( bRecorderInitialised )
     {
+
+        // message only if the state appears to change
+        if ( bEnableRecording != bNewEnableRecording )
+        {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
+// TODO we should use the ConsoleWriterFactory() instead of qInfo()
+            qInfo() << "Recording state" << ( bNewEnableRecording ? "enabled" : "disabled" );
+#endif
+        }
+
         // note that this block executes regardless of whether
         // what appears to be a change is being applied, to ensure
         // the requested state is the result
         bEnableRecording = bNewEnableRecording;
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qInfo()
-        qInfo() << "Recording state" << ( bEnableRecording ? "enabled" : "disabled" );
-#endif
 
         if ( !bEnableRecording )
         {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1580,6 +1580,7 @@ void CServer::SetEnableRecording ( bool bNewEnableRecording )
 {
     JamController.SetEnableRecording ( bNewEnableRecording, IsRunning() );
 
+    // not dependent upon JamController state
     bDisableRecording = !bNewEnableRecording;
 
     // the recording state may have changed, send recording state message

--- a/src/server.h
+++ b/src/server.h
@@ -210,6 +210,7 @@ public:
     bool GetRecorderInitialised() { return JamController.GetRecorderInitialised(); }
     QString GetRecorderErrMsg() { return JamController.GetRecorderErrMsg(); }
     bool GetRecordingEnabled() { return JamController.GetRecordingEnabled(); }
+    bool GetDisableRecording() { return bDisableRecording; }
     void RequestNewRecording() { JamController.RequestNewRecording(); }
 
     void SetEnableRecording ( bool bNewEnableRecording );

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -330,7 +330,7 @@ lvwClients->setMinimumHeight ( 140 );
 #endif
 
     // Recorder controls
-    chbEnableRecorder->setCheckState ( Qt::CheckState::Checked ); // move to settings
+    chbEnableRecorder->setChecked ( pServer->GetRecordingEnabled() );
     edtCurrentSessionDir->setText ( "" );
     pbtNewRecording->setAutoDefault ( false );
     pbtRecordingDir->setAutoDefault ( false );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -879,6 +879,15 @@ if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
     {
         pServer->SetRecordingDir ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "server", "recordingdir_base64" ) ) );
     }
+
+    // norecord flag
+    if ( !CommandLineOptions.contains ( "--norecord" ) )
+    {
+         if ( GetFlagIniSet ( IniXMLDocument, "server", "norecord", bValue ) )
+         {
+             pServer->SetEnableRecording( !bValue );
+         }
+    }
 }
 
 void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
@@ -930,4 +939,8 @@ void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // base recording directory
     PutIniSetting ( IniXMLDocument, "server", "recordingdir_base64",
         ToBase64 ( pServer->GetRecordingDir() ) );
+
+    // norecord flag
+    SetFlagIniSet ( IniXMLDocument, "server", "norecord",
+        pServer->GetDisableRecording() );
 }


### PR DESCRIPTION
"norecord" value of "1" stored in inifile when Enable recorder is not checked in GUI, else stored as "0".

If --norecord is passed, stored value is not read (hence recorder remains disabled).

If --norecord is not passed, stored value is read and passed to recorder.

Recorder amended only to log (apparent) _change_ in state.

(Because CServer is running before its configuration has been fully determined, this means that the recorder will still start up enabled if --norecord, issuing its state message; if the inifile then sets it to norecord, it will issue a second message for the change in state.)