### PR TITLE
Slightly randomize starting port

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -67,12 +67,19 @@ void CSocket::Init ( const quint16 iPortNumber )
         {
             // if the port is not available, try "NUM_SOCKET_PORTS_TO_TRY" times
             // with incremented port numbers
+
+            // Randomize the start by 5 ports, in case a faulty router gets
+            // stuck and confused by a particular port (like the starting port).
+            // Might work around frustrating "cannot connect" problems.
+
+            quint16 startingPortNumber = iPortNumber + rand() % 5;
+
             quint16 iClientPortIncrement = 0;
             bSuccess                     = false; // initialization for while loop
 
             while ( !bSuccess && ( iClientPortIncrement <= NUM_SOCKET_PORTS_TO_TRY ) )
             {
-                UdpSocketInAddr.sin_port = htons ( iPortNumber + iClientPortIncrement );
+                UdpSocketInAddr.sin_port = htons ( startingPortNumber + iClientPortIncrement );
 
                 bSuccess = ( ::bind ( UdpSocket ,
                                     (sockaddr*) &UdpSocketInAddr,


### PR DESCRIPTION
Issue #568 documents problems connecting to a server. The symptoms were narrowed down to a scenario where one client is connected to the server, using port (default + 10 = 22134), and then disconnected. A second client on another machine is started and attempts to connect to the server, and is given the same port number (22134) as a matter of course, since it's the first port number to try. Due to what is probably a faulty router (or some other mechanism?), that port is in fact still associated with the first machine, even though Jamulus is not running there, having been already disconnected from the server. The result is the UDP packets for the second machine are wrongly sent to the first machine. This results in the behavior where the server thinks the new client is connected, but the new client does not, because it is not receiving packets from the server. This behavior persists over an indeterminate amount of time, leading to much frustration on the part of the user trying to connect.

One workaround was suggested in #568 where if a client is not able to reconnect, the initial port used in finding an available can be manually changed from the standard 22134 starting port number to some other number, by specifying the starting port number on the command line using the -p option.  While that seems to work, this pull request suggests a more automatic way to work around the issue: Instead of always starting with default + 10 (22134) port number, start instead with default + 10 + some small random number. Chances are then good that any problem due to a "sticky port" on a faulty router (or wherever it happens) is bypassed.

NOTE: Since the assignment of starting port number is done in the initial phases of the client startup, if the client fails to connect, the user should shut down Jamulus and try again, upon which a different starting port number will be used.