### PR TITLE
#618 Make recorder thread-safe

### DIFF
--- a/src/recorder/jamrecorder.h
+++ b/src/recorder/jamrecorder.h
@@ -27,6 +27,7 @@
 #include <QDir>
 #include <QFile>
 #include <QDateTime>
+#include <QMutex>
 
 #include "../util.h"
 #include "../channel.h"
@@ -169,6 +170,7 @@ private:
     int          iServerFrameSizeSamples;
     bool         isRecording;
     CJamSession* currentSession;
+    QMutex       ChIdMutex;
 
 signals:
     void RecordingSessionStarted ( QString sessionDir );


### PR DESCRIPTION
I had a look through all the signals handled by the jam recorder and, as far as I can tell, I've covered the places where there could be contention.

I've tested that a single client can connect successfully and recording still works...  I had a go at recreating the race condition by stopping the server, rather than having the client disconnect.  Couldn't get it to crash (but I've done that before locally and it's not crashed, so I doubt it's a "good test").

So, any ideas on reproducing the crash conditions would be appreciated! :)