### PR TITLE
Minor scaling factor fixes

### DIFF
--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -580,8 +580,9 @@ bool CSound::CheckSampleTypeSupported ( const ASIOSampleType SamType )
         ( SamType == ASIOSTInt32MSB24 ) );
 }
 
+// Might want to comment that use of double in factors below avoids nasty conversion surprises
 static constexpr double FACTOR16     = 32767.0;
-static constexpr double FACTOR16_INV = 1.0 / 32767.0;
+static constexpr double FACTOR16_INV = 1.0 / 32768.0; // Notice diff in last digit from other factor, ala Port Audio
 
 struct sample16LSB
 {
@@ -618,8 +619,9 @@ struct sample16MSB
     }
 };
 
+// Might want to comment that use of double in factors below avoids nasty conversion surprises
 static constexpr double FACTOR24     = 2147483647.0;
-static constexpr double FACTOR24_INV = 1.0 / 2147483647.0;
+static constexpr double FACTOR24_INV = 1.0 / 2147483648.0; // Notice diff in last digit from other factor, ala Port Audio
 
 struct sample24LSB
 {
@@ -663,8 +665,9 @@ struct sample24MSB
     }
 };
 
+// Might want to comment that use of double in factors below avoids nasty conversion surprises.
 static constexpr double FACTOR32     = 2147483647.0;
-static constexpr double FACTOR32_INV = 1.0 / 2147483647.0;
+static constexpr double FACTOR32_INV = 1.0 / 2147483648.0; // Notice diff in last digit from other factor, ala Port Audio
 
 struct sample32LSB
 {


### PR DESCRIPTION
I suggest a few slight tweaks to the conversion scale factors.

(1) The tweaks are only strictly "necessary" on the 16 bit / float conversions. Prevents max negative integer from converting to a float that's slightly bigger than one. This is in keeping with the way Port Audio does these conversions.

(2) Not strictly necessary for 32 bit / float conversions, but keeps things consistent and is in keeping with the way Port Audio does these conversions.

(3) Added two comments to remind anyone who might change this code down the line that there is a reason double precision is used for the 32 bit / float scale factors. Not strictly necessary for the 16 bit / float conversions, so I didn't add a comment there.  (Update: Somehow the comment survived in the 16 bit / float case). But maybe best to keep the double precision scale factors there for consistency's sake.

These tweaks are in keeping with comments I made on the original hselasky pull request.