### PR TITLE
Concurrency tweaks

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -927,7 +927,7 @@ static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TE
             MixFutureSynchronizer.clearFutures();
 
             // Each thread must complete within the 1 or 2ms time budget for the timer.
-            const int iMaximumMixOpsInTimeBudget = 900;  // Approximate limit as observed on GCP e2-standard instance
+            const int iMaximumMixOpsInTimeBudget = 500;  // Approximate limit as observed on GCP e2-standard instance
                                                           // TODO - determine at startup by running a small benchmark
             const int iMTBlockSize = iMaximumMixOpsInTimeBudget / iNumClients; // number of ops = block size * total number of clients
             const int iNumBlocks   = ( iNumClients - 1 ) / iMTBlockSize + 1;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1037,9 +1037,13 @@ static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TE
         // processing with multithreading
         if ( bUseMultithreading )
         {
+            // make sure all concurrent run threads from prior call have finished before we start again
+            FutureSynchronizer.waitForFinished();
+            FutureSynchronizer.clearFutures();
+
             // Each thread must complete within the 1 or 2ms time budget for the timer.
-            const int iMaximumMixOpsInTimeBudget = 500;  // Approximate limit as observed on GCP e2-standard instance
-                                                         // TODO - determine at startup by running a small benchmark
+            const int iMaximumMixOpsInTimeBudget = 1800;  // Approximate limit as observed on GCP e2-standard instance
+                                                          // TODO - determine at startup by running a small benchmark
             const int iMTBlockSize = iMaximumMixOpsInTimeBudget / iNumClients; // number of ops = block size * total number of clients
             const int iNumBlocks   = static_cast<int> ( std::ceil ( static_cast<double> ( iNumClients ) / iMTBlockSize ) );
 
@@ -1060,10 +1064,6 @@ static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TE
                                                                    iNumClients,
                                                                    iChannelDataPage ) );
             }
-
-            // make sure all concurrent run threads have finished when we leave this function
-            FutureSynchronizer.waitForFinished();
-            FutureSynchronizer.clearFutures();
         }
     }
     else

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -827,7 +827,7 @@ static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TE
         // process connected channels
         if (bUseMultithreading) {
             const int iDBlockSize = 20;
-            const int iNumBlocks   = static_cast<int> ( std::ceil ( static_cast<double> ( iNumClients ) / iDBlockSize ) );
+            const int iNumBlocks   = ( iNumClients - 1 ) / iDBlockSize + 1;
 
             for ( int iBlockCnt = 0; iBlockCnt < iNumBlocks; iBlockCnt++ )
             {
@@ -930,7 +930,7 @@ static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TE
             const int iMaximumMixOpsInTimeBudget = 900;  // Approximate limit as observed on GCP e2-standard instance
                                                           // TODO - determine at startup by running a small benchmark
             const int iMTBlockSize = iMaximumMixOpsInTimeBudget / iNumClients; // number of ops = block size * total number of clients
-            const int iNumBlocks   = static_cast<int> ( std::ceil ( static_cast<double> ( iNumClients ) / iMTBlockSize ) );
+            const int iNumBlocks   = ( iNumClients - 1 ) / iMTBlockSize + 1;
 
             for ( int iBlockCnt = 0; iBlockCnt < iNumBlocks; iBlockCnt++ )
             {
@@ -1089,6 +1089,7 @@ unsigned short CServer::DecodeDataBlocks ( const int iStartChanCnt,
                     {
                         emit ClientDisconnected ( currentChan.iChanID ); // TODO do this outside the mutex lock?
                     }
+                    hashChannelIndex.remove(vecChannels[currentChan.iChanID].GetAddress());
 
                     bChannelIsNowDisconnected = true;
                 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -690,6 +690,7 @@ void CServer::OnCLDisconnection ( CHostAddress InetAddr )
     if ( iCurChanID != INVALID_CHANNEL_ID )
     {
         vecChannels[iCurChanID].Disconnect();
+        hashChannelIndex.remove(InetAddr);
     }
 }
 
@@ -1437,21 +1438,8 @@ int CServer::GetNumberOfConnectedClients()
 
 int CServer::FindChannel ( const CHostAddress& CheckAddr )
 {
-    CHostAddress InetAddr;
-
-    // check for all possible channels if IP is already in use
-    for ( int i = 0; i < iMaxNumChannels; i++ )
-    {
-        // the "GetAddress" gives a valid address and returns true if the
-        // channel is connected
-        if ( vecChannels[i].GetAddress ( InetAddr ) )
-        {
-            // IP found, return channel number
-            if ( InetAddr == CheckAddr )
-            {
-                return i;
-            }
-        }
+    if (hashChannelIndex.contains(CheckAddr)) {
+        return hashChannelIndex[CheckAddr];
     }
 
     // IP not found, return invalid ID
@@ -1549,6 +1537,8 @@ bool CServer::PutAudioData ( const CVector<uint8_t>& vecbyRecBuf,
         {
             // in case we have a new connection return this information
             bNewConnection = true;
+            // also remember in the index
+            hashChannelIndex[HostAdr] = iCurChanID;
         }
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -330,6 +330,7 @@ protected:
     // do not use the vector class since CChannel does not have appropriate
     // copy constructor/operator
     CChannel                   vecChannels[MAX_NUM_CHANNELS];
+    QHash<CHostAddress,int>    hashChannelIndex;
     int                        iMaxNumChannels;
     CProtocol                  ConnLessProtocol;
     QMutex                     Mutex;

--- a/src/server.h
+++ b/src/server.h
@@ -326,11 +326,10 @@ protected:
 
     void WriteHTMLChannelList();
 
-    bool DecodeDataBlocks ( const int iStartChanCnt,
+    unsigned short DecodeDataBlocks ( const int iStartChanCnt,
                             const int iStopChanCnt, 
                             const int iNumClients, 
-                            const int page,
-                            bool& bUpdateChannelLevels);
+                            const int page);
 
     void MixEncodeTransmitDataBlocks ( const int iStartChanCnt,
                                        const int iStopChanCnt,
@@ -350,7 +349,7 @@ protected:
     // variables needed for multithreading support
     bool                      bUseMultithreading;
     QFutureSynchronizer<void> MixFutureSynchronizer;
-    QFutureSynchronizer<bool> DecodeFutureSynchronizer;
+    QFutureSynchronizer<unsigned short> DecodeFutureSynchronizer;
 
     bool CreateLevelsForAllConChannels  ( const int                          iNumClients,
                                           const CVector<CurrentChannelData>& vecCurrentChannelData,

--- a/src/server.h
+++ b/src/server.h
@@ -326,6 +326,12 @@ protected:
 
     void WriteHTMLChannelList();
 
+    bool DecodeDataBlocks ( const int iStartChanCnt,
+                            const int iStopChanCnt, 
+                            const int iNumClients, 
+                            const int page,
+                            bool& bUpdateChannelLevels);
+
     void MixEncodeTransmitDataBlocks ( const int iStartChanCnt,
                                        const int iStopChanCnt,
                                        const int iNumClients,
@@ -343,7 +349,8 @@ protected:
 
     // variables needed for multithreading support
     bool                      bUseMultithreading;
-    QFutureSynchronizer<void> FutureSynchronizer;
+    QFutureSynchronizer<void> MixFutureSynchronizer;
+    QFutureSynchronizer<bool> DecodeFutureSynchronizer;
 
     bool CreateLevelsForAllConChannels  ( const int                          iNumClients,
                                           const CVector<CurrentChannelData>& vecCurrentChannelData,

--- a/src/server.h
+++ b/src/server.h
@@ -320,7 +320,6 @@ protected:
 
     // variables needed for multithreading support
     bool                      bUseMultithreading;
-    QFutureSynchronizer<void> FutureSynchronizer;
 
     bool CreateLevelsForAllConChannels  ( const int                        iNumClients,
                                           const CVector<int>&              vecNumAudioChannels,

--- a/src/util.h
+++ b/src/util.h
@@ -834,6 +834,10 @@ public:
     quint16      iPort;
 };
 
+inline uint qHash(const CHostAddress& adr, uint seed) {
+    return qHash(adr.InetAddr, seed) + qHash(adr.iPort, seed);
+}
+
 
 // Instrument picture data base ------------------------------------------------
 // this is a pure static class


### PR DESCRIPTION
See #455 

With the included changes, I'm able to accomodate 96 clients on an 8-core server before there is packet loss and sound quality degrades. (mono/stereo, 128, no recording enabled.) Same system maxed out at 65 without these changes, all other things equal.

There are still some low-hanging fruit for improvements. There's some unnecessary work building a channel list inside the main decode loop; that could instead be updated only when a new channel joins or leaves (similar to the hashmap added in this changeset.)

Key changes
* Created a hashmap-based lookup of channel by hostaddress for use in PutPacket
* Increased the size of the thread pool
* Moved decode data into structs and made two pages of them, so decode can write one page while mix reads the other (then they trade.)
* Moved the futuresync wait to take advantage of this paging
* Split decode work into multiple threads by blocks similar to how mixing is done.