### PR TITLE
Initial working Android Code

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1019,3 +1019,5 @@ contains(CONFIG, "disable_version_check") {
     message(The version check is disabled.)
     DEFINES += DISABLE_VERSION_CHECK
 }
+
+ANDROID_ABIS = armeabi-v7a arm64-v8a

--- a/android/sound.cpp
+++ b/android/sound.cpp
@@ -34,8 +34,6 @@ CSound::CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData
                  const QString& ) :
     CSoundBase ( "OpenSL", fpNewProcessCallback, arg, iCtrlMIDIChannel )
 {
-    pSound = this;
-
 #ifdef ANDROIDDEBUG
     qInstallMessageHandler(myMessageHandler);
 #endif
@@ -45,11 +43,12 @@ void CSound::setupCommonStreamParams(oboe::AudioStreamBuilder *builder)
 {
     // We request EXCLUSIVE mode since this will give us the lowest possible
     // latency. If EXCLUSIVE mode isn't available the builder will fall back to SHARED mode
-    builder->setCallback(this)
+    builder
             ->setFormat(oboe::AudioFormat::Float)
-            ->setSharingMode(oboe::SharingMode::Shared)
-            ->setChannelCount(oboe::ChannelCount::Mono)
-           // ->setSampleRate(48000)
+            ->setSharingMode(oboe::SharingMode::Exclusive)
+            ->setChannelCount(oboe::ChannelCount::Stereo)
+            ->setSampleRate(48000)
+            ->setFramesPerCallback(iOpenSLBufferSizeMono)
            // ->setSampleRateConversionQuality(oboe::SampleRateConversionQuality::Medium)
             ->setPerformanceMode(oboe::PerformanceMode::None);
 
@@ -73,14 +72,17 @@ void CSound::openStreams()
     {
         return;
     }
-
-    mPlayStream->setBufferSizeInFrames ( pSound->iOpenSLBufferSizeStereo );
+    mPlayStream->setBufferSizeInFrames ( iOpenSLBufferSizeStereo );
 
     warnIfNotLowLatency ( mPlayStream, "PlayStream" );
     printStreamDetails ( mPlayStream );
 
     // Setup input stream
     inBuilder.setDirection ( oboe::Direction::Input );
+
+    // Only set callback for the input direction
+    // the output will be handled writing directly on the stream
+    inBuilder.setCallback(this);
     setupCommonStreamParams ( &inBuilder );
 
     result = inBuilder.openManagedStream ( mRecordingStream );
@@ -91,7 +93,7 @@ void CSound::openStreams()
         return;
     }
 
-    mRecordingStream->setBufferSizeInFrames ( pSound->iOpenSLBufferSizeStereo );
+    mRecordingStream->setBufferSizeInFrames ( iOpenSLBufferSizeStereo );
 
     warnIfNotLowLatency ( mRecordingStream, "RecordStream" );
     printStreamDetails ( mRecordingStream );
@@ -184,7 +186,7 @@ void CSound::Stop()
 int CSound::Init ( const int iNewPrefMonoBufferSize )
 {
     // store buffer size
-    iOpenSLBufferSizeMono = 512; // iNewPrefMonoBufferSize;
+    iOpenSLBufferSizeMono = iNewPrefMonoBufferSize; // 512
 
     // init base class
     CSoundBase::Init ( iOpenSLBufferSizeMono );
@@ -193,19 +195,13 @@ int CSound::Init ( const int iNewPrefMonoBufferSize )
     iOpenSLBufferSizeStereo = 2 * iOpenSLBufferSizeMono;
 
     // create memory for intermediate audio buffer
-    vecsTmpAudioSndCrdStereo.Init ( iOpenSLBufferSizeStereo );
+    vecsTmpInputAudioSndCrdStereo.Init ( iOpenSLBufferSizeStereo );
+    vecsTmpOutAudioSndCrdStereo.Init ( iOpenSLBufferSizeStereo );
 
 // TEST
 #if ( SYSTEM_SAMPLE_RATE_HZ != 48000 )
 # error "Only a system sample rate of 48 kHz is supported by this module"
 #endif
-// audio interface number of channels is 1 and the sample rate
-// is 16 kHz -> just copy samples and perform no filtering as a
-// first simple solution
-// 48 kHz / 16 kHz = factor 3 (note that the buffer size mono might
-// be divisible by three, therefore we will get a lot of drop outs)
-iModifiedInBufSize = iOpenSLBufferSizeMono / 3;
-vecsTmpAudioInSndCrd.Init ( iModifiedInBufSize );
 
     return iOpenSLBufferSizeMono;
 }
@@ -216,31 +212,45 @@ vecsTmpAudioInSndCrd.Init ( iModifiedInBufSize );
 oboe::DataCallbackResult CSound::onAudioReady ( oboe::AudioStream* oboeStream, void* audioData, int32_t numFrames )
 {
     // only process if we are running
-    if ( ! pSound->bRun )
+    if ( ! bRun )
     {
         return oboe::DataCallbackResult::Continue;
     }
 
-    // Need to modify the size of the buffer based on the numFrames requested in this callback.
-    // Buffer size can change regularly by android devices
-    int& iBufferSizeMono = pSound->iOpenSLBufferSizeMono;
-
-    // perform the processing for input and output
-//    QMutexLocker locker ( &pSound->Mutex );
-//    locker.mutex();
-
-    // This can be called from both input and output at different times
-    if ( oboeStream == pSound->mPlayStream.get() && audioData )
+    if ( oboeStream == mRecordingStream.get() && audioData )
     {
-        float *floatData = static_cast<float*> ( audioData );
+        // First things first, we need to discard the input queue a little for 500ms or so
+        if ( mCountCallbacksToDrain > 0 )
+        {
+            // discard the input buffer
+            int32_t numBytes = numFrames * oboeStream->getBytesPerFrame();
+            memset ( audioData, 0 /* value */, numBytes );
+            mCountCallbacksToDrain--;
+        }
 
-        // Zero out the incoming container array
-        memset ( audioData, 0, sizeof(float) * numFrames * oboeStream->getChannelCount() );
+        // We're good to start recording now
+        // Take the data from the recording device output buffer and move
+        // it to the vector ready to send up to the server
+        float *floatData = static_cast<float*> ( audioData );
+        // Copy recording data to internal vector
+        for ( int frmNum = 0; frmNum < numFrames; ++frmNum )
+        {
+            for ( int channelNum = 0; channelNum < oboeStream->getChannelCount(); channelNum++ )
+            {
+                vecsTmpInputAudioSndCrdStereo[frmNum * oboeStream->getChannelCount() + channelNum] =
+                    static_cast<int16_t>(floatData[frmNum * oboeStream->getChannelCount() + channelNum] * _MAXSHORT);
+            }
+        }
+
+        // Tell parent class that we've put some data ready to send to the server
+        ProcessCallback ( vecsTmpInputAudioSndCrdStereo  );
+
+        // The callback has placed in the vector the samples to play
 
         // Only copy data if we have data to copy, otherwise fill with silence
-        if ( !pSound->vecsTmpAudioSndCrdStereo.empty() )
+        if ( !vecsTmpInputAudioSndCrdStereo.empty() )
         {
-            for ( int frmNum = 0; frmNum < numFrames; ++frmNum )
+            for ( int frmNum = 0; frmNum < iOpenSLBufferSizeMono; ++frmNum )
             {
                 for ( int channelNum = 0; channelNum < oboeStream->getChannelCount(); channelNum++ )
                 {
@@ -248,50 +258,34 @@ oboe::DataCallbackResult CSound::onAudioReady ( oboe::AudioStream* oboeStream, v
 
                     // convert to 32 bit
                     const int32_t iCurSam = static_cast<int32_t> (
-                        pSound->vecsTmpAudioSndCrdStereo [frmNum * oboeStream->getChannelCount() + channelNum] );
+                        vecsTmpInputAudioSndCrdStereo [frmNum * oboeStream->getChannelCount() + channelNum] );
 
-                    floatData[frmNum * oboeStream->getChannelCount() + channelNum] = (float) iCurSam / _MAXSHORT;
+                    vecsTmpOutAudioSndCrdStereo[frmNum * oboeStream->getChannelCount() + channelNum] = ((float) iCurSam) / _MAXSHORT;
                 }
             }
         }
         else
         {
             // prime output stream buffer with silence
-            memset(static_cast<float*> ( audioData ) + numFrames * oboeStream->getChannelCount(), 0,
-                ( numFrames ) * oboeStream->getBytesPerFrame() );
-        }
-    }
-    else if ( oboeStream == pSound->mRecordingStream.get() && audioData )
-    {
-        // First things first, we need to discard the input queue a little for 500ms or so
-        if ( pSound->mCountCallbacksToDrain > 0 )
-        {
-            // discard the input buffer
-            int32_t numBytes = numFrames * oboeStream->getBytesPerFrame();
-            memset ( audioData, 0 /* value */, numBytes );
-            pSound->mCountCallbacksToDrain--;
+            vecsTmpOutAudioSndCrdStereo.Reset(0);
         }
 
-        // We're good to start recording now
-        // Take the data from the recording device output buffer and move
-        // it to the vector ready to send up to the server
-        float *floatData = static_cast<float*> ( audioData );
-
-        // Copy recording data to internal vector
-        for ( int frmNum = 0; frmNum < numFrames; ++frmNum )
+        // Write without blocking.
+        oboe::ResultWithValue<int32_t> r = mPlayStream->write(vecsTmpOutAudioSndCrdStereo.data(),iOpenSLBufferSizeMono,0);
+        if(r)
         {
-            for ( int channelNum = 0; channelNum < oboeStream->getChannelCount(); channelNum++ )
+            // Note: this could result in not writing the requested number of frames.
+            // We could buffer them and wait for the next occasion, but for now we just discard them.
+            if(r.value() < iOpenSLBufferSizeMono)
             {
-                pSound->vecsTmpAudioSndCrdStereo[frmNum * oboeStream->getChannelCount() + channelNum] =
-                    (short) floatData[frmNum * oboeStream->getChannelCount() + channelNum] * _MAXSHORT;
+                qDebug() << "Could only write " << r.value() << " frames of the " << iOpenSLBufferSizeMono << " requested.";
             }
         }
-
-        // Tell parent class that we've put some data ready to send to the server
-        pSound->ProcessCallback ( pSound->vecsTmpAudioSndCrdStereo  );
+        else
+        {
+            qDebug() << "Could not write to output stream: " << oboe::convertToText(r.error());
+        }
     }
-
-//  locker.unlock();
 
     return oboe::DataCallbackResult::Continue;
 }

--- a/android/sound.h
+++ b/android/sound.h
@@ -31,7 +31,6 @@
 #include <QDebug>
 #include <android/log.h>
 
-
 /* Classes ********************************************************************/
 class CSound : public CSoundBase, public oboe::AudioStreamCallback//, public IRenderableAudio, public IRestartable
 {
@@ -52,9 +51,9 @@ public:
     virtual void onErrorAfterClose ( oboe::AudioStream* oboeStream, oboe::Result result );
     virtual void onErrorBeforeClose ( oboe::AudioStream* oboeStream, oboe::Result result );
 
-    // these variables should be protected but cannot since we want
-    // to access them from the callback function
-    CVector<short> vecsTmpAudioSndCrdStereo;
+protected:
+    CVector<short> vecsTmpInputAudioSndCrdStereo;
+    CVector<float> vecsTmpOutAudioSndCrdStereo;
 
     static void android_message_handler ( QtMsgType                 type,
                                           const QMessageLogContext& context,
@@ -72,10 +71,6 @@ public:
 
         __android_log_print ( priority, "Qt", "%s", qPrintable ( message ) );
     };
-
-// TEST
-CVector<short> vecsTmpAudioInSndCrd;
-int            iModifiedInBufSize;
 
     int            iOpenSLBufferSizeMono;
     int            iOpenSLBufferSizeStereo;
@@ -96,9 +91,4 @@ private:
     // empty and the garbage in the first 500ms or so is discarded
     static constexpr int32_t kNumCallbacksToDrain = 10;
     int32_t mCountCallbacksToDrain = kNumCallbacksToDrain;
-
-    // Used to reference this instance of class from within the static callback
-    CSound *pSound;
-
-    QMutex Mutex;
 };

--- a/android/sound.h
+++ b/android/sound.h
@@ -25,14 +25,13 @@
 #pragma once
 
 #include <oboe/Oboe.h>
-#include <QMutex>
 #include "soundbase.h"
 #include "global.h"
 #include <QDebug>
 #include <android/log.h>
 
 /* Classes ********************************************************************/
-class CSound : public CSoundBase, public oboe::AudioStreamCallback//, public IRenderableAudio, public IRestartable
+class CSound : public CSoundBase, public oboe::AudioStreamCallback
 {
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),


### PR DESCRIPTION
This pull request contains code changes to the already existing android code solving some of the issues. It is linked to Issue #83.

It has been minimally tested on a Google Pixel 3a but I could listen to other participants and they could hear me.

Key things are:

- Initialize the Oboe's FramesPerCallback to the proposed `iNewPrefMonoBufferSize` in `CSound::Init()`
- Only set up with a callback the input/recording stream. The output/playing stream will be written directly (non-blocking) everytime we get a callback on the input. This matches how CClient does things.
- Fixed the converstion from float to int16_t that previously resulted in the input being zero.
- Added a second vector (float) to contain the reformatted output samples. Once the default format becomes float, this could go away.

I guess there's still a lot of work to do in the handling of error cases and possible variations in the oboe behaviour across different devices, but I hope this could be a starting point.

Please comment.