### PR TITLE
Additional changes to the initial Android support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Makefile
 .project
 .settings
 .idea
+.vscode
 *.user
 *.user.*
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Makefile
 .cproject
 .project
 .settings
+.idea
 *.user
 *.user.*
 *.o

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -350,6 +350,7 @@ FORMS_GUI = src/clientdlgbase.ui \
     src/aboutdlgbase.ui
 
 HEADERS += src/buffer.h \
+    android/ring_buffer.h \
     src/channel.h \
     src/client.h \
     src/global.h \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1025,4 +1025,4 @@ contains(CONFIG, "disable_version_check") {
     DEFINES += DISABLE_VERSION_CHECK
 }
 
-ANDROID_ABIS = armeabi-v7a arm64-v8a
+ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64

--- a/android/ring_buffer.h
+++ b/android/ring_buffer.h
@@ -1,0 +1,172 @@
+/******************************************************************************\
+ * Copyright (c) 2004-2020
+ *
+ * Author(s):
+ *  Simon Tomlinson, Volker Fischer
+ *
+ ******************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ *
+\******************************************************************************/
+
+#pragma once
+#include <vector>
+
+/**
+ * Implementantion of a ring buffer.
+ * Data is contained in a vector dynamically allocated.
+ */
+template<typename T>
+class RingBuffer {
+public:
+    /**
+     * @brief RingBuffer
+     * @param max maximum number of elements that can be contained in the ring buffer
+     */
+    RingBuffer(std::size_t max = 0):mData(max),mRead(0),mWrite(0),mFull(false) { }
+
+    /**
+     * @brief Resets the ring_buffer
+     * @param max maximum number of elements that can be contained in the ring buffer.
+     */
+    void reset(std::size_t max = 0) {
+        mData = std::vector<T>(max);
+        mRead = 0;
+        mWrite = 0;
+        mFull = false;
+    }
+
+    /**
+     * @brief Current number of elements contained in the ring buffer
+     * @return
+     */
+    std::size_t size() const {
+        std::size_t size = capacity();
+        if(!mFull) {
+            if(mWrite >= mRead) {
+                size = mWrite - mRead;
+            } else {
+                size = capacity() + mWrite - mRead;
+            }
+        }
+        return size;
+    }
+
+    /**
+     * @brief whether the ring buffer is full
+     * @return
+     */
+    bool isFull() const { return mFull; }
+
+    /**
+     * @brief whether the ring buffer is empty.
+     * @return
+     */
+    bool isEmpty() const { return !isFull() && (mRead == mWrite); }
+
+    /**
+     * @brief Maximum number of elements in the ring buffer
+     * @return
+     */
+    std::size_t capacity() const { return mData.size(); }
+
+    /**
+     * @brief Adds a single value
+     * @param v the value to add
+     */
+    void put(const T &v) {
+        mData[mWrite] = v;
+        forward();
+    }
+
+    /**
+     * @brief Reads a single value
+     * @param v the value read
+     * @return true if the value was read
+     */
+    bool get(T&v) {
+        if(!isEmpty()) {
+            v = mData[mRead];
+            backward();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Adds a multiple consecutive values
+     * @param v pointer to the consecutive values
+     * @param count number of consecutive values.
+     */
+    void put(const T *v, std::size_t count) {
+        std::size_t avail = mWrite - capacity();
+        std::size_t to_copy = std::min(count,avail);
+        memcpy(mData.data() + mWrite,v, to_copy*sizeof(T));
+        forward(to_copy);
+        if(to_copy < count) {
+            put(v+to_copy,count - to_copy);
+        }
+    }
+
+    /**
+     * @brief Reads multiple values
+     * @param v pointer to the memory wher ethe values will be written
+     * @param count Maximum available size in the memory area
+     * @return actual number of elements read.
+     */
+    std::size_t get(T *v, std::size_t count) {
+        std::size_t avail = 0;
+        if(mRead < mWrite) {
+            avail = mWrite - mRead;
+        } else {
+            avail = mRead - capacity();
+        }
+        std::size_t to_copy = std::min(count, avail);
+        memcpy(v, mData.data() + mRead, to_copy * sizeof(T));
+        backward(to_copy);
+        if((size()>0)&&(count > to_copy)) {
+            return to_copy + get(v + to_copy, count - to_copy);
+        } else {
+            return to_copy;
+        }
+    }
+private:
+    void forward() {
+        if(isFull()) {
+            mRead = (mRead + 1) % capacity();
+        }
+        mWrite = (mWrite + 1) % capacity();
+        mFull = (mRead == mWrite);
+    }
+
+    void forward(std::size_t count) {
+        for(std::size_t i=0; i<count;i++) {
+            forward();
+        }
+    }
+
+    void backward(std::size_t count) {
+        mFull = false;
+        mRead = (mRead + count) % capacity();
+    }
+
+    std::vector<T> mData;
+    std::size_t mRead;  /** offset to reading point */
+    std::size_t mWrite; /** offset to writing point */
+    bool mFull;
+};
+


### PR DESCRIPTION
Related to Issue #83
Testing with different devices I found that the previous approach, where the output stream was written synchronously and non-blocking on the callback from the input stream, was not working for devices using the OpenSL backend.

So I've changed the implementation to:
- Have a circular buffer to store the output samples received from the CClient callback.
- Have the output stream set with a callback too that will extract samples from the circular buffer.

Added a Stats struct to keep track of some counters while experimenting.

I've tested this build in three devices:
- Google Pixel 3XL on Android 10.
- Google Pixel 3a on Android 11.
- BQ Aquaris X5 Plus on Android 7.1.1
