### PR TITLE
Add missing #include <QVersionNumber> in classes that use it

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -28,6 +28,7 @@
 #include <QDateTime>
 #include <QFile>
 #include <QTextStream>
+#include <QVersionNumber>
 #include "global.h"
 #include "buffer.h"
 #include "util.h"

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -36,6 +36,7 @@
 #include <QSystemTrayIcon>
 #include <QSettings>
 #include <QFileDialog>
+#include <QVersionNumber>
 #include "global.h"
 #include "server.h"
 #include "settings.h"


### PR DESCRIPTION
It's already included in `clientdlg.h`.

This fixes building with Qt 5.7 on Debian stable -- it's OK with Qt 5.13 (presumably because one of the other headers transitively includes `QVersionNumber`).