### PR TITLE
Add version guards for QVersionNumber includes.

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -28,7 +28,9 @@
 #include <QDateTime>
 #include <QFile>
 #include <QTextStream>
-#include <QVersionNumber>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+# include <QVersionNumber>
+#endif
 #include "global.h"
 #include "buffer.h"
 #include "util.h"

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -36,7 +36,9 @@
 #include <QSystemTrayIcon>
 #include <QSettings>
 #include <QFileDialog>
-#include <QVersionNumber>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+# include <QVersionNumber>
+#endif
 #include "global.h"
 #include "server.h"
 #include "settings.h"


### PR DESCRIPTION
This header was introduced in Qt 5.6.

This should fix the build problem commented on in #686.