### PR TITLE
generate compiled translation files correctly

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -668,6 +668,16 @@ DISTFILES += ChangeLog \
     README.md \
     distributions/jamulus.desktop.in \
     distributions/jamulus.png \
+    src/res/translation/translation_de_DE.qm \
+    src/res/translation/translation_fr_FR.qm \
+    src/res/translation/translation_pt_PT.qm \
+    src/res/translation/translation_pt_BR.qm \
+    src/res/translation/translation_es_ES.qm \
+    src/res/translation/translation_nl_NL.qm \
+    src/res/translation/translation_pl_PL.qm \
+    src/res/translation/translation_it_IT.qm \
+    src/res/translation/translation_sv_SE.qm \
+    src/res/translation/translation_sk_SK.qm \
     src/res/CLEDBlack.png \
     src/res/CLEDBlackSmall.png \
     src/res/CLEDDisabledSmall.png \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -8,6 +8,7 @@ contains(CONFIG, "noupcasename") {
 
 CONFIG += qt \
     thread \
+    lrelease \
     release
 
 QT += network \
@@ -21,6 +22,7 @@ contains(CONFIG, "headless") {
     QT += widgets
 }
 
+LRELEASE_DIR = src/res/translation
 TRANSLATIONS = src/res/translation/translation_de_DE.ts \
     src/res/translation/translation_fr_FR.ts \
     src/res/translation/translation_pt_PT.ts \
@@ -666,16 +668,6 @@ DISTFILES += ChangeLog \
     README.md \
     distributions/jamulus.desktop.in \
     distributions/jamulus.png \
-    src/res/translation/translation_de_DE.qm \
-    src/res/translation/translation_fr_FR.qm \
-    src/res/translation/translation_pt_PT.qm \
-    src/res/translation/translation_pt_BR.qm \
-    src/res/translation/translation_es_ES.qm \
-    src/res/translation/translation_nl_NL.qm \
-    src/res/translation/translation_pl_PL.qm \
-    src/res/translation/translation_it_IT.qm \
-    src/res/translation/translation_sv_SE.qm \
-    src/res/translation/translation_sk_SK.qm \
     src/res/CLEDBlack.png \
     src/res/CLEDBlackSmall.png \
     src/res/CLEDDisabledSmall.png \


### PR DESCRIPTION
- restore qmake’s `lrelease` option
- let the resource compiler pick up the compiled files correctly
- remove the precompiled binaries from the repository

Tested in Debian.

A possible improvement on this is to set `CONFIG += embed_translations` as well and **don’t** add them to `src/resources.qrc` (but let qmake do that); we’d have to redo the part that lists the available translations in `src/util.cpp:CLocale::GetAvailableTranslations()` then (but given it maps all languages from *xx_XX* to *xx* except Portuguese is doubled, some more insightful algorithm might be used there anyway, or the consumers could just deal with having the countries there as well).