### PR TITLE
Automatically build Debian packages and set latest tag to release

### DIFF
--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pre-release:
     name: "Pre Release"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-16.04"
     steps:
       - name: Checkout Project
         uses: actions/checkout@v1

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -1,4 +1,4 @@
-name: "pre-release"
+name: "Autobuild deb"
 
 on:
   push:
@@ -8,14 +8,11 @@ jobs:
   pre-release:
     name: "Pre Release"
     runs-on: "ubuntu-latest"
-
     steps:
-      # ...
       - name: Checkout Project
         uses: actions/checkout@v1
-      - name: "Build & test"
+      - name: "Build package"
         run: cd distributions; sudo ./build-debian-package-auto.sh
-
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -1,0 +1,26 @@
+name: "pre-release"
+
+on:
+  push:
+    branches:
+      - "autobuild_linux"
+jobs:
+  pre-release:
+    name: "Pre Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      # ...
+      - name: Checkout Project
+        uses: actions/checkout@v1
+      - name: "Build & test"
+        run: cd distributions; sudo apt-get -qq update; sudo apt-get -qq -y upgrade; sudo apt-get -qq -y install devscripts build-essential debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools; mv debian ..; cd ..; debuild -b -us -uc; mv debian distributions; cd ..; cp *.deb jamulus/
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            *.deb

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v1
       - name: "Build & test"
-        run: cd distributions; sudo apt-get -qq update; sudo apt-get -qq -y upgrade; sudo apt-get -qq -y install devscripts build-essential debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools; mv debian ..; cd ..; debuild -b -us -uc; mv debian distributions; cd ..; cp *.deb jamulus/
+        run: cd distributions; sudo build-debian-package-auto.sh
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -2,11 +2,11 @@ name: "Autobuild deb"
 
 on:
   push:
-    branches:
-      - "autobuild_linux"
+    tags:
+      - "r*"
 jobs:
   pre-release:
-    name: "Pre Release"
+    name: "Release"
     runs-on: "ubuntu-18.04"
     steps:
       - name: Checkout Project
@@ -16,8 +16,8 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "nightly"
-          prerelease: true
+          automatic_release_tag: "latest"
+          prerelease: false
           title: "Development Build"
           files: |
             *.deb

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          automatic_release_tag: "nightly"
           prerelease: true
           title: "Development Build"
           files: |

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v1
       - name: "Build & test"
-        run: cd distributions; sudo build-debian-package-auto.sh
+        run: cd distributions; sudo ./build-debian-package-auto.sh
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -18,6 +18,6 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           prerelease: false
-          title: "Development Build"
+          title: "Automatic Build"
           files: |
             *.deb

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pre-release:
     name: "Pre Release"
-    runs-on: "ubuntu-16.04"
+    runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout Project
         uses: actions/checkout@v1

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pre-release:
     name: "Pre Release"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-18.04"
     steps:
       - name: Checkout Project
         uses: actions/checkout@v1

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pre-release:
     name: "Pre Release"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-16.04"
     steps:
       - name: Checkout Project
         uses: actions/checkout@v1

--- a/distributions/autobuilddeb/control
+++ b/distributions/autobuilddeb/control
@@ -14,9 +14,7 @@ Vcs-Browser: https://github.com/corrados/jamulus
 
 Package: jamulus
 Architecture: any
-Depends:
- ${shlibs:Depends},
- ${misc:Depends},
+Depends: libc6 (>= 2.17), libgcc1 (>= 1:3.0), libjack-jackd2-0 (>= 1.9.5~dfsg-14) | libjack-0.116, libqt5core5a (>= 5.5.0), libqt5gui5 (>= 5.0.2) | libqt5gui5-gles (>= 5.0.2), libqt5network5 (>= 5.0.2), libqt5widgets5 (>= 5.2.0), libqt5xml5 (>= 5.0.2), libstdc++6 (>= 5.2)
 Description: Low latency Audio Server/Client
  The Jamulus software enables musicians to perform real-time jam sessions over
  the internet. There is one server running the Jamulus server software which

--- a/distributions/autobuilddeb/control
+++ b/distributions/autobuilddeb/control
@@ -1,0 +1,43 @@
+Source: jamulus
+Section: sound
+Priority: optional
+Maintainer: "corrados" <nomail@example.com>
+Build-Depends:
+ debhelper (>= 9),
+ libjack-jackd2-dev,
+ qtbase5-dev,
+ qttools5-dev-tools,
+Standards-Version: é&%JAMVERSION%&è
+Homepage: https://jamulus.io
+Vcs-Git: git://github.com/corrados/jamulus.git
+Vcs-Browser: https://github.com/corrados/jamulus
+
+Package: jamulus
+Architecture: any
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+Description: Low latency Audio Server/Client
+ The Jamulus software enables musicians to perform real-time jam sessions over
+ the internet. There is one server running the Jamulus server software which
+ collects the audio data from each Jamulus client, mixes the audio data and
+ sends the mix back to each client.
+ .
+ It runs on Windows / macOS / Linux.
+
+Package: jamulus-headless
+Architecture: any
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+ adduser,
+Description: Low latency Audio Server (headless)
+ The Jamulus software enables musicians to perform real-time jam sessions over
+ the internet. There is one server running the Jamulus server software which
+ collects the audio data from each Jamulus client, mixes the audio data and
+ sends the mix back to each client.
+ .
+ It runs on Windows / macOS / Linux.
+ .
+ This package contains a Jamulus binary built for headless operation
+ (without GUI library dependencies) and a jamulus-headless systemd service.

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -11,9 +11,19 @@ sudo apt-get -qq -y install devscripts build-essential \
 cp -r debian ..
 cd ..
 
-# patch the control file
 # get the jamulus version from pro file
 VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
+
+# patch changelog
+DATE=$(date "+%a, %d %B %Y %T %Z" )
+echo "-- GitHub Actions <noemail@example.com> ${DATE}" >> debian/changelog
+echo "" >> debian/changelog
+echo "* See GitHub releases for changelog"
+echo "" >> debian/changelog
+echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" >> debian/changelog
+
+
+# patch the control file
 # move the modified control file here
 
 cp distributions/autobuilddeb/control debian/control

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -25,6 +25,7 @@ echo "" >> debian/changelog
 echo "  * See GitHub releases for changelog" >> debian/changelog
 echo "" >> debian/changelog
 echo "-- GitHub Actions <noemail@example.com> ${DATE}" >> debian/changelog
+echo "" >> debian/changelog
 cat distributions/debian/changelog >> debian/changelog
 
 # patch the control file
@@ -39,6 +40,6 @@ debuild -b -us -uc
 
 echo "Build armhf"
 
-debuilf -b -us -uc -aarmhf
+debuild -b -us -uc -aarmhf
 # copy for auto release
 cp ../*.deb ./

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -19,12 +19,12 @@ VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
 
 # patch changelog (with hack)
 
-DATE=$(date "+%a, %d %B %Y %T %Z" )
+DATE=$(date "+%a, %d %B %Y %T" )
 echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" > debian/changelog
 echo "" >> debian/changelog
 echo "  * See GitHub releases for changelog" >> debian/changelog
 echo "" >> debian/changelog
-echo "-- GitHub Actions <noemail@example.com> ${DATE}" >> debian/changelog
+echo "-- GitHub Actions <noemail@example.com> ${DATE} + 0" >> debian/changelog
 echo "" >> debian/changelog
 cat distributions/debian/changelog >> debian/changelog
 

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -38,6 +38,7 @@ echo "${VERSION} building..."
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 debuild -b -us -uc
 
+sudo dpkg -i *.deb
 #echo "Build armhf"
 
 #debuild -b -us -uc -aarmhf

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+# set armhf
+sudo dpkg --add-architecture armhf
+
 echo "Update system..."
 sudo apt-get -qq update
 sudo apt-get -qq -y upgrade
@@ -34,5 +37,8 @@ echo "${VERSION} building..."
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 debuild -b -us -uc
 
+echo "Build armhf"
+
+debuilf -b -us -uc -aarmhf
 # copy for auto release
 cp ../*.deb ./

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+echo "Update system..."
+sudo apt-get -qq update
+sudo apt-get -qq -y upgrade
+echo "Install dependencies..."
+
+sudo apt-get -qq -y install devscripts build-essential \
+ debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools
+
+cp -r debian ..
+cd ..
+
+# patch the control file
+# get the jamulus version from pro file
+VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
+# move the modified control file here
+
+cp distributions/autobuilddeb/control debian/control
+
+echo "${VERSION} building..."
+
+sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
+debuild -b -us -uc
+
+# copy for auto release
+cp ../*.deb ./

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # set armhf
-sudo dpkg --add-architecture armhf
+#sudo dpkg --add-architecture armhf
 
 echo "Update system..."
 sudo apt-get -qq update

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -18,7 +18,7 @@ VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
 DATE=$(date "+%a, %d %B %Y %T %Z" )
 echo "-- GitHub Actions <noemail@example.com> ${DATE}" >> debian/changelog
 echo "" >> debian/changelog
-echo "* See GitHub releases for changelog"
+echo "* See GitHub releases for changelog" >> debian/changelog
 echo "" >> debian/changelog
 echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" >> debian/changelog
 

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -9,7 +9,7 @@ sudo apt-get -qq -y upgrade
 echo "Install dependencies..."
 
 sudo apt-get -qq -y install devscripts build-essential \
- debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools gcc-arm-linux-gnueabihf
+ debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools # gcc-arm-linux-gnueabihf
 
 cp -r debian ..
 cd ..
@@ -38,8 +38,8 @@ echo "${VERSION} building..."
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 debuild -b -us -uc
 
-echo "Build armhf"
+#echo "Build armhf"
 
-debuild -b -us -uc -aarmhf
+#debuild -b -us -uc -aarmhf
 # copy for auto release
 cp ../*.deb ./

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -9,7 +9,7 @@ sudo apt-get -qq -y upgrade
 echo "Install dependencies..."
 
 sudo apt-get -qq -y install devscripts build-essential \
- debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools
+ debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools gcc-arm-linux-gnueabihf
 
 cp -r debian ..
 cd ..

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -38,9 +38,10 @@ echo "${VERSION} building..."
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 debuild -b -us -uc
 
-sudo dpkg -i *.deb
 #echo "Build armhf"
 
 #debuild -b -us -uc -aarmhf
 # copy for auto release
 cp ../*.deb ./
+
+sudo dpkg -i *.deb

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -24,7 +24,7 @@ echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" > debian/changelog
 echo "" >> debian/changelog
 echo "  * See GitHub releases for changelog" >> debian/changelog
 echo "" >> debian/changelog
-echo "-- GitHub Actions <noemail@example.com> ${DATE} + 0" >> debian/changelog
+echo " -- GitHub Actions <noemail@example.com> ${DATE} +0" >> debian/changelog
 echo "" >> debian/changelog
 cat distributions/debian/changelog >> debian/changelog
 

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -14,17 +14,18 @@ cd ..
 # get the jamulus version from pro file
 VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
 
-# patch changelog
-DATE=$(date "+%a, %d %B %Y %T %Z" )
-echo "-- GitHub Actions <noemail@example.com> ${DATE}" >> debian/changelog
-echo "" >> debian/changelog
-echo "* See GitHub releases for changelog" >> debian/changelog
-echo "" >> debian/changelog
-echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" >> debian/changelog
+# patch changelog (with hack)
 
+DATE=$(date "+%a, %d %B %Y %T %Z" )
+echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" > debian/changelog
+echo "" >> debian/changelog
+echo "  * See GitHub releases for changelog" >> debian/changelog
+echo "" >> debian/changelog
+echo "-- GitHub Actions <noemail@example.com> ${DATE}" >> debian/changelog
+cat distributions/debian/changelog >> debian/changelog
 
 # patch the control file
-# move the modified control file here
+# cp the modified control file here
 
 cp distributions/autobuilddeb/control debian/control
 


### PR DESCRIPTION
#795 

This will make the release process slightly different (mainly the latest tag will be set automatically).

If somebody adds a tag with r and pushes it to the repo, GitHub actions will compile the .deb files from the latest code and upload it to a release: https://github.com/ann0see/jamulus/releases/tag/latest

Hacks/Bugs:

I currently compile Jamulus on Ubuntu 18.04 but use the 16.04 dependencies. This seems to allow us to have the pan function on Debian 10 but doesn't show the muted icon in the main mixer. Hopefully it doesn't break anything else

