### PR TITLE
Try to fix headless build dependencies and rename deb files automatically

### DIFF
--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -1,9 +1,6 @@
 name: "Autobuild deb"
 
-on:
-  push:
-    tags:
-      - "r*"
+on: push
 jobs:
   pre-release:
     name: "Release"

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -17,4 +17,4 @@ jobs:
           prerelease: false
           title: "Automatic Build"
           files: |
-            *.deb
+            deploy/*.deb

--- a/.github/workflows/autobuild_deb.yml
+++ b/.github/workflows/autobuild_deb.yml
@@ -1,6 +1,9 @@
 name: "Autobuild deb"
 
-on: push
+on:
+  push:
+    tags:
+      - "r*"
 jobs:
   pre-release:
     name: "Release"

--- a/distributions/autobuilddeb/control
+++ b/distributions/autobuilddeb/control
@@ -25,10 +25,7 @@ Description: Low latency Audio Server/Client
 
 Package: jamulus-headless
 Architecture: any
-Depends:
- ${shlibs:Depends},
- ${misc:Depends},
- adduser,
+Depends: libqt5core5a (>= 5.5.0), libqt5gui5 (>= 5.0.2) | libqt5gui5-gles (>= 5.0.2), libqt5network5 (>= 5.0.2), libqt5widgets5 (>= 5.2.0), libqt5xml5 (>= 5.0.2)
 Description: Low latency Audio Server (headless)
  The Jamulus software enables musicians to perform real-time jam sessions over
  the internet. There is one server running the Jamulus server software which

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -24,7 +24,7 @@ echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" > debian/changelog
 echo "" >> debian/changelog
 echo "  * See GitHub releases for changelog" >> debian/changelog
 echo "" >> debian/changelog
-echo " -- GitHub Actions <noemail@example.com> ${DATE} +0" >> debian/changelog
+echo " -- GitHub Actions <noemail@example.com> ${DATE} +0000" >> debian/changelog
 echo "" >> debian/changelog
 cat distributions/debian/changelog >> debian/changelog
 
@@ -38,10 +38,11 @@ echo "${VERSION} building..."
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 debuild -b -us -uc
 
-#echo "Build armhf"
+mkdir deploy
 
 #debuild -b -us -uc -aarmhf
 # copy for auto release
-cp ../*.deb ./
+cp ../*.deb deploy/
 
-sudo dpkg -i *.deb
+mv deploy/jamulus-headless*_amd64.deb deploy/Jamulus_headless_latest_amd64.deb
+mv deploy/jamulus*_amd64.deb deploy/Jamulus_latest_amd64.deb


### PR DESCRIPTION
This will add the same dependencies from the gui build except the jack dependencies to the headless debian build.

Also the .deb files now no longer have the version in their file name --> easy download once the version changes since the name stays the same.