### PR TITLE
Add flatpak build support, with CI

### DIFF
--- a/.github/workflows/autobuild_flatpak.yml
+++ b/.github/workflows/autobuild_flatpak.yml
@@ -2,6 +2,7 @@ on:
   push:
     tags:
       - "r*"
+  workflow_dispatch:
 name: "Autobuild Flatpak"
 jobs:
   flatpak-builder:

--- a/.github/workflows/autobuild_flatpak.yml
+++ b/.github/workflows/autobuild_flatpak.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    tags:
+      - "r*"
+name: "Autobuild Flatpak"
+jobs:
+  flatpak-builder:
+    name: "Flatpak Builder"
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bilelmoussaoui/flatpak-github-actions@v2
+      with:
+        bundle: "io.jamulus.Jamulus.flatpak"
+        manifest-path: "distributions/io.jamulus.Jamulus.json"

--- a/distributions/io.jamulus.Jamulus.json
+++ b/distributions/io.jamulus.Jamulus.json
@@ -1,0 +1,44 @@
+{
+  "app-id": "io.jamulus.Jamulus",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.15",
+  "sdk": "org.kde.Sdk",
+  "command": "Jamulus",
+  "rename-desktop-file": "jamulus.desktop",
+  "rename-icon": "jamulus",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=wayland",
+    "--device=dri"
+  ],
+  "modules": [
+    {
+      "name": "jack2",
+      "buildsystem": "simple",
+      "build-commands": [
+      	"./waf configure --prefix=/app --htmldir=/app/share/doc/jack/ --classic",
+      	"./waf build -j $FLATPAK_BUILDER_N_JOBS",
+      	"./waf install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/jackaudio/jack2/archive/v1.9.16.tar.gz",
+          "sha256": "e176d04de94dcaa3f9d32ca1825091e1b938783a78c84e7466abd06af7637d37"
+        }
+      ]
+    },
+    {
+      "name": "jamulus",
+      "buildsystem": "qmake",
+      "sources": [
+        {
+          "type": "git",
+          "url": "../",
+          "branch": "master"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Warning: I can say it compiles and runs, but I don't have jack installed and my sound card isn't working, so I can't test anything.
Before this PR gets accepted, someone should test this.

To manually build the flatpak release, you can run
```
flatpak-builder build distributions/io.jamulus.Jamulus.json --force-clean --install --user
```

Then Jamulus should show up in your app list.
If you want to launch it from the terminal

```
flatpak run io.jamulus.Jamulus
```

This solves #803 
Enjoy