### PR TITLE
Fix for #811 - Channel Layout Minor Tweaks

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -42,6 +42,7 @@ CChannelFader::CChannelFader ( QWidget* pNW ) :
     pPan                        = new QDial       ( pLevelsBox );
     pPanLabel                   = new QLabel      ( tr ( "Pan" ), pLevelsBox );
     pInfoLabel                  = new QLabel      ( "", pLevelsBox );
+    pInfoLabel->setMinimumSize(36, 36); // prevents jitter when muting/unmuting
 
     pMuteSoloBox                = new QWidget     ( pFrame );
     pcbMute                     = new QCheckBox   ( tr ( "Mute" ), pMuteSoloBox );
@@ -216,7 +217,7 @@ void CChannelFader::SetGUIDesign ( const EGUIDesign eNewDesign )
             "          border-left:   20px transparent;"
             "          border-right:  -25px transparent; }"
             "QSlider::groove { image:          url();"
-            "                  padding-left:   -38px;"
+            "                  padding-left:   -34px;"
             "                  padding-top:    -10px;"
             "                  padding-bottom: -15px; }"
             "QSlider::handle { image: url(:/png/fader/res/faderhandle.png); }" );

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -42,7 +42,6 @@ CChannelFader::CChannelFader ( QWidget* pNW ) :
     pPan                        = new QDial       ( pLevelsBox );
     pPanLabel                   = new QLabel      ( tr ( "Pan" ), pLevelsBox );
     pInfoLabel                  = new QLabel      ( "", pLevelsBox );
-    pInfoLabel->setMinimumSize(36, 36); // prevents jitter when muting/unmuting
 
     pMuteSoloBox                = new QWidget     ( pFrame );
     pcbMute                     = new QCheckBox   ( tr ( "Mute" ), pMuteSoloBox );
@@ -82,13 +81,14 @@ CChannelFader::CChannelFader ( QWidget* pNW ) :
     pFader->setTickInterval ( AUD_MIX_FADER_MAX / 9 );
 
     // setup panning control
-    pPan->setRange          ( 0, AUD_MIX_PAN_MAX );
-    pPan->setValue          ( AUD_MIX_PAN_MAX / 2 );
-    pPan->setNotchesVisible ( true );
-    pPanInfoGrid->addWidget ( pPanLabel, 0, Qt::AlignLeft );
-    pPanInfoGrid->addWidget ( pInfoLabel );
-    pPanGrid->addLayout     ( pPanInfoGrid );
-    pPanGrid->addWidget     ( pPan, 0, Qt::AlignHCenter );
+    pPan->setRange             ( 0, AUD_MIX_PAN_MAX );
+    pPan->setValue             ( AUD_MIX_PAN_MAX / 2 );
+    pPan->setNotchesVisible    ( true );
+    pInfoLabel->setMinimumSize ( 36, 36 ); // prevents jitter when muting/unmuting
+    pPanInfoGrid->addWidget    ( pPanLabel, 0, Qt::AlignLeft );
+    pPanInfoGrid->addWidget    ( pInfoLabel );
+    pPanGrid->addLayout        ( pPanInfoGrid );
+    pPanGrid->addWidget        ( pPan, 0, Qt::AlignHCenter );
 
     // setup fader tag label (black bold text which is centered)
     plblLabel->setTextFormat ( Qt::PlainText );


### PR DESCRIPTION
Minor tweaks for the channel layout

1. Set a minimum size on the info widget so that if the text content is empty it still occupies space in the layout.
2. Adjust the horizontal alignment of the fader handle to center it over the slot.

**How built:** Windows Qt/VS2019 x86
**How verified:** Windows Desktop
- Server: FamJam
- Normal/Fancy/Compact skins