### PR TITLE
Working Jack(pipewire drop-in compat) in Flatpak

### DIFF
--- a/distributions/io.jamulus.Jamulus.json
+++ b/distributions/io.jamulus.Jamulus.json
@@ -10,7 +10,11 @@
     "--share=ipc",
     "--socket=x11",
     "--socket=wayland",
-    "--device=dri"
+    "--share=network",
+    "--filesystem=xdg-run/pipewire-0",
+    "--socket=system-bus",
+    "--socket=pulseaudio",
+    "--device=all"
   ],
   "modules": [
     {
@@ -27,6 +31,9 @@
           "url": "https://github.com/jackaudio/jack2/archive/v1.9.16.tar.gz",
           "sha256": "e176d04de94dcaa3f9d32ca1825091e1b938783a78c84e7466abd06af7637d37"
         }
+      ],
+      "cleanup": [
+      	"*"
       ]
     },
     {


### PR DESCRIPTION
Based on the help of flatpak/flatpak#1509
Now it seems to work. It opens without giving any jack related error.

![Screenshot from 2021-01-08 18-34-10](https://user-images.githubusercontent.com/23294184/104046978-2d092e80-51e1-11eb-9fa4-70cb846f7a2b.png)

But. Again. I don't know if this actually outputs sound or not.
Related to #803 


