### PR TITLE
Win installer: Add ASIO detection

### DIFF
--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -66,6 +66,34 @@ Function Get-RedirectedUrl {
     }
 }
 
+function Load-Module ($m) { # see https://stackoverflow.com/a/51692402
+
+    # If module is imported say that and do nothing
+    if (Get-Module | Where-Object {$_.Name -eq $m}) {
+        write-host "Module $m is already imported."
+    }
+    else {
+
+        # If module is not imported, but available on disk then import
+        if (Get-Module -ListAvailable | Where-Object {$_.Name -eq $m}) {
+            Import-Module $m
+        }
+        else {
+
+            # If module is not imported, not available on disk, but is in online gallery then install and import
+            if (Find-Module -Name $m | Where-Object {$_.Name -eq $m}) {
+                Install-Module -Name $m -Force -Verbose -Scope CurrentUser
+                Import-Module $m
+            }
+            else {
+
+                # If module is not imported, not available and not in online gallery then abort
+                write-host "Module $m not imported, not available and not in online gallery, exiting."
+                EXIT 1
+            }
+        }
+    }
+}
 
 # Download and uncompress dependency in ZIP format
 Function Install-Dependency
@@ -100,8 +128,10 @@ Function Install-Dependency
 # Install VSSetup (Visual Studio detection), ASIO SDK and NSIS Installer
 Function Install-Dependencies
 {
-    Install-PackageProvider -Name "Nuget" -Scope CurrentUser -Force
-    Install-Module -Name "VSSetup" -Scope CurrentUser -Force
+    if (-not (Get-PackageProvider -Name nuget).Name -eq "nuget") {
+      Install-PackageProvider -Name "Nuget" -Scope CurrentUser -Force
+    }
+    Load-Module -m "VSSetup"
     Install-Dependency -Uri $AsioSDKUrl `
         -Name $AsioSDKName -Destination "ASIOSDK2"
     Install-Dependency -Uri $NsisUrl `


### PR DESCRIPTION
Since #821 is not yet ready, I think it makes sense to detect a missing ASIO driver. 

Current behaviour:

If there's no ASIO key in the registry --> Show a page which links to jamulus.io

If the user exits this page and the key is still missing --> Show a warning where the user can descide if he wants to continue to install jamulus. This is needed since the server doesn't need an ASIO driver installed. 

