### PR TITLE
Feature/android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,24 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ feature/android ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -47,6 +47,7 @@ DEFINES += APP_VERSION=\\\"$$VERSION\\\" \
     USE_ALLOCA \
     CUSTOM_MODES \
     _REENTRANT
+DEFINES += "BOOL_CLOSE_DIALOGS_ON_BACKBUTTON=0" # fixes android ui issue
 
 # some depreciated functions need to be kept for older versions to build
 # TODO as soon as we drop support for the old Qt version, remove the following line
@@ -175,6 +176,9 @@ win32 {
 
     # enabled only for debugging on android devices
     DEFINES += ANDROIDDEBUG
+
+    DEFINES -= BOOL_CLOSE_DIALOGS_ON_BACKBUTTON=0  # fixes android ui issue
+    DEFINES += BOOL_CLOSE_DIALOGS_ON_BACKBUTTON=1  # fixes android ui issue
 
     target.path = /tmp/your_executable # path on device
     INSTALLS += target

--- a/src/analyzerconsole.cpp
+++ b/src/analyzerconsole.cpp
@@ -220,3 +220,13 @@ int CAnalyzerConsole::CalcYPosInGraph ( const double dAxisMin,
     return GraphGridFrame.y() + static_cast<int> (
         static_cast<double> ( GraphGridFrame.height() ) * ( 1 - dYValNorm ) );
 }
+
+void CAnalyzerConsole::keyPressEvent ( QKeyEvent *e )
+{
+    if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
+        this->close(); // otherwise, dialog does not show properly again in android
+        return;
+    }else{
+        QDialog::keyPressEvent ( e );
+    }
+}

--- a/src/analyzerconsole.h
+++ b/src/analyzerconsole.h
@@ -31,6 +31,7 @@
 #include <QImage>
 #include <QPainter>
 #include <QTimer>
+#include <QKeyEvent>
 #include "client.h"
 
 
@@ -87,4 +88,6 @@ protected:
 
 public slots:
     void OnTimerErrRateUpdate();
+
+    void keyPressEvent ( QKeyEvent *e );
 };

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -140,3 +140,19 @@ void CChatDlg::OnAnchorClicked ( const QUrl& Url )
         }
     }
 }
+
+void CChatDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
+{
+#ifdef Q_OS_ANDROID
+    if ( e->key() == Qt::Key_Back ){
+        this->close(); // otherwise, dialog does not show properly again
+        return;
+    }
+#endif
+    if ( e->key() == Qt::Key_Escape ){
+        ; // ignore escape key
+    }else{
+        QDialog::keyPressEvent ( e );
+    }
+}
+

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -143,14 +143,11 @@ void CChatDlg::OnAnchorClicked ( const QUrl& Url )
 
 void CChatDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
 {
-#ifdef Q_OS_ANDROID
-    if ( e->key() == Qt::Key_Back ){
-        this->close(); // otherwise, dialog does not show properly again
-        return;
-    }
-#endif
     if ( e->key() == Qt::Key_Escape ){
         ; // ignore escape key
+    }else if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
+        this->close(); // otherwise, dialog does not show properly again
+        return;
     }else{
         QDialog::keyPressEvent ( e );
     }

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -146,7 +146,7 @@ void CChatDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android 
     if ( e->key() == Qt::Key_Escape ){
         ; // ignore escape key
     }else if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
-        this->close(); // otherwise, dialog does not show properly again
+        this->close(); // otherwise, dialog does not show properly again in android
         return;
     }else{
         QDialog::keyPressEvent ( e );

--- a/src/chatdlg.h
+++ b/src/chatdlg.h
@@ -54,8 +54,7 @@ public slots:
     void OnClearChatHistory();
     void OnAnchorClicked ( const QUrl& Url );
 
-    void keyPressEvent ( QKeyEvent *e ) // block escape key
-        { if ( e->key() != Qt::Key_Escape ) QDialog::keyPressEvent ( e ); }
+    void keyPressEvent ( QKeyEvent *e );
 
 signals:
     void NewLocalInputText ( QString strNewText );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1354,3 +1354,15 @@ rbtReverbSelR->setStyleSheet ( "" );
     // also apply GUI design to child GUI controls
     MainMixerBoard->SetGUIDesign ( eNewDesign );
 }
+
+void CClientDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
+{
+    if ( e->key() == Qt::Key_Escape ){
+        ; // ignore escape key
+    }else if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
+        this->close(); // otherwise, dialog does not show properly again in android
+        return;
+    }else{
+        QDialog::keyPressEvent ( e );
+    }
+}

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -238,6 +238,5 @@ public slots:
 
     void accept() { close(); } // introduced by pljones
 
-    void keyPressEvent ( QKeyEvent *e ) // block escape key
-        { if ( e->key() != Qt::Key_Escape ) QDialog::keyPressEvent ( e ); }
+    void keyPressEvent ( QKeyEvent *e );
 };

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -754,3 +754,14 @@ void CClientSettingsDlg::UpdateCustomCentralServerComboBox()
         }
     }
 }
+
+void CClientSettingsDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
+{
+#ifdef Q_OS_ANDROID
+    if ( e->key() == Qt::Key_Back ){
+        this->close(); // otherwise, dialog does not show properly again
+        return;
+    }
+#endif
+    QDialog::keyPressEvent ( e );
+}

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -757,11 +757,10 @@ void CClientSettingsDlg::UpdateCustomCentralServerComboBox()
 
 void CClientSettingsDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
 {
-#ifdef Q_OS_ANDROID
-    if ( e->key() == Qt::Key_Back ){
+    if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
         this->close(); // otherwise, dialog does not show properly again
         return;
+    }else{
+        QDialog::keyPressEvent ( e );
     }
-#endif
-    QDialog::keyPressEvent ( e );
 }

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -758,7 +758,7 @@ void CClientSettingsDlg::UpdateCustomCentralServerComboBox()
 void CClientSettingsDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
 {
     if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
-        this->close(); // otherwise, dialog does not show properly again
+        this->close(); // otherwise, dialog does not show properly again in android
         return;
     }else{
         QDialog::keyPressEvent ( e );

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -37,6 +37,7 @@
 #include <QLayout>
 #include <QButtonGroup>
 #include <QMessageBox>
+#include <QKeyEvent>
 #include "global.h"
 #include "client.h"
 #include "settings.h"
@@ -107,6 +108,7 @@ public slots:
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnDriverSetupClicked();
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
+    void keyPressEvent ( QKeyEvent *e );
 
 signals:
     void GUIDesignChanged();

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -921,3 +921,13 @@ void CConnectDlg::DeleteAllListViewItemChilds ( QTreeWidgetItem* pItem )
         delete pCurChildItem;
     }
 }
+
+void CConnectDlg::keyPressEvent ( QKeyEvent *e )
+{
+    if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
+        this->close(); // otherwise, dialog does not show properly again in android
+        return;
+    }else{
+        QDialog::keyPressEvent ( e );
+    }
+}

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -31,6 +31,7 @@
 #include <QTimer>
 #include <QLocale>
 #include <QtConcurrent>
+#include <QKeyEvent>
 #include "global.h"
 #include "settings.h"
 #include "multicolorled.h"
@@ -108,6 +109,8 @@ public slots:
     void OnConnectClicked();
     void OnTimerPing();
     void OnTimerReRequestServList();
+
+    void keyPressEvent ( QKeyEvent *e );
 
 signals:
     void ReqServerListQuery ( CHostAddress InetAddr );

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -834,3 +834,15 @@ void CServerDlg::changeEvent ( QEvent* pEvent )
         }
     }
 }
+
+void CServerDlg::keyPressEvent ( QKeyEvent *e ) // block escape key & fix android back key
+{
+    if ( e->key() == Qt::Key_Escape ){
+        ; // ignore escape key
+    }else if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
+        this->close(); // otherwise, dialog does not show properly again in android
+        return;
+    }else{
+        QDialog::keyPressEvent ( e );
+    }
+}

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -114,8 +114,7 @@ public slots:
     void OnSysTrayActivated ( QSystemTrayIcon::ActivationReason ActReason );
     void OnWelcomeMessageChanged() { pServer->SetWelcomeMessage ( tedWelcomeMessage->toPlainText() ); }
 
-    void keyPressEvent ( QKeyEvent *e ) // block escape key
-        { if ( e->key() != Qt::Key_Escape ) QDialog::keyPressEvent ( e ); }
+    void keyPressEvent ( QKeyEvent *e );
 
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnNewRecordingClicked() { pServer->RequestNewRecording(); }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -848,6 +848,16 @@ void CMusProfDlg::OnSkillActivated ( int iCntryListItem )
     pClient->SetRemoteInfo();
 }
 
+void CMusProfDlg::keyPressEvent ( QKeyEvent *e )
+{
+    if (BOOL_CLOSE_DIALOGS_ON_BACKBUTTON && ( e->key() == Qt::Key_Back )){
+        this->close(); // otherwise, dialog does not show properly again in android
+        return;
+    }else{
+        QDialog::keyPressEvent ( e );
+    }
+}
+
 
 // Help menu -------------------------------------------------------------------
 CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&Help" ), parent )

--- a/src/util.h
+++ b/src/util.h
@@ -38,6 +38,7 @@
 # include <QLineEdit>
 # include <QDateTime>
 # include <QDesktopServices>
+# include <QKeyEvent>
 # include "ui_aboutdlgbase.h"
 #endif
 #include <QFile>
@@ -420,6 +421,8 @@ public slots:
     void OnCountryActivated ( int iCntryListItem );
     void OnCityTextChanged ( const QString& strNewName );
     void OnSkillActivated ( int iCntryListItem );
+
+    void keyPressEvent ( QKeyEvent *e );
 };
 
 


### PR DESCRIPTION
fix for bug ui on android
contributes to #83

Bug description:
Dialogs like the Settings- or Chat-Window pop ob in Foreground and fullscreen. After closing them via system's backbutton, they do not show propperly again, but still obstruct the main-window when opened. Closing those dialogs via close() makes them behave normally and reusable (noticed with the Connect-dialog)

