### PR TITLE
Create automatic release on tag push with content of ChangeLog (not only latest release)

### DIFF
--- a/.github/actions_scripts/get_release_vars.sh
+++ b/.github/actions_scripts/get_release_vars.sh
@@ -2,5 +2,6 @@
 
 VERSION=$(cat ${1}/Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
 echo "::set-output name=JAMULUS_VERSION::${VERSION}"
-
+# get the tag which pushed this
+echo "::set-output name=PUSH_TAG::${GITHUB_REF#refs/*/}"
 perl ${1}/.github/actions_scripts/getChangelog.pl ${1}/ChangeLog ${VERSION} > ${1}/autoLatestChangelog.md

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,142 +1,142 @@
-name:                         Publish Release
 on:
   push:
     tags:
       - "r*"
   workflow_dispatch:
+name:                               Publish Release
 jobs:
   create_release:
-     name:                    Create release
-     runs-on:                 ubuntu-latest
+     name:                          Create release
+     runs-on:                       ubuntu-latest
      outputs:
-      upload_url:             ${{ steps.create_release.outputs.upload_url }}
-      upload_latest_url:      ${{ steps.create_latest_release.outputs.upload_url }}
-      version:                ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }}
+      upload_url:                   ${{ steps.create_release.outputs.upload_url }}
+      upload_latest_url:            ${{ steps.create_latest_release.outputs.upload_url }}
+      version:                      ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }}
      steps:
-         - name:              Checkout code
-           uses:              actions/checkout@v2
-         - name:              Get Jamulus build info
-           run:               sh ${{ github.workspace }}/.github/actions_scripts/get_release_vars.sh ${{ github.workspace }}
-           id:                jamulus-build-vars
-         - name:              Remove latest tag
-           uses:              dev-drprasad/delete-tag-and-release@v0.1.2
+         - name:                    Checkout code
+           uses:                    actions/checkout@v2
+         - name:                    Get Jamulus build info
+           run:                     sh ${{ github.workspace }}/.github/actions_scripts/get_release_vars.sh ${{ github.workspace }}
+           id:                      jamulus-build-vars
+         - name:                    Remove latest tag
+           uses:                    dev-drprasad/delete-tag-and-release@v0.1.2
            with:
-             delete_release:  true
-             tag_name:        latest # tag name to delete
+             delete_release:        true
+             tag_name:              latest # tag name to delete
            env:
-             GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
-         - name:              Prepare latest release
-           id:                create_latest_release
-           uses:              actions/create-release@v1
+             GITHUB_TOKEN:          ${{ secrets.GITHUB_TOKEN }}
+         - name:                    Prepare latest release
+           id:                      create_latest_release
+           uses:                    actions/create-release@v1
            env:
-             GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+             GITHUB_TOKEN:          ${{ secrets.GITHUB_TOKEN }}
            with:
-             tag_name:        latest
-             release_name:    Latest release ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }} (auto build)
-             body_path:       ${{ github.workspace }}/autoLatestChangelog.md
-             draft:           false
-             prerelease:      false
-         - name:              Prepare tag release
-           id:                create_release
-           uses:              actions/create-release@v1
+             tag_name:              latest
+             release_name:          Latest release ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }} (auto build)
+             body_path:             ${{ github.workspace }}/autoLatestChangelog.md
+             draft:                 false
+             prerelease:            false
+         - name:                    Prepare tag release
+           id:                      create_release
+           uses:                    actions/create-release@v1
            env:
-             GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+             GITHUB_TOKEN:          ${{ secrets.GITHUB_TOKEN }}
            with:
-             tag_name:        ${{ steps.jamulus-build-vars.outputs.PUSH_TAG }}
-             release_name:    Release ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }} (auto build)
-             body_path:       ${{ github.workspace }}/autoLatestChangelog.md
-             draft:           false
-             prerelease:      false
+             tag_name:              ${{ steps.jamulus-build-vars.outputs.PUSH_TAG }}
+             release_name:          Release ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }} (auto build)
+             body_path:             ${{ github.workspace }}/autoLatestChangelog.md
+             draft:                 false
+             prerelease:            false
   release_assets:
-    name:                     Release assets
-    needs:                    create_release
-    runs-on:                  ${{ matrix.config.os }}
+    name:                           Release assets
+    needs:                          create_release
+    runs-on:                        ${{ matrix.config.os }}
     strategy:
       matrix:
         config:
-           - os:                     ubuntu-18.04
-             asset_path:             deploy/Jamulus_latest_amd64.deb
-             asset_name:             jamulus_${{ needs.create_release.outputs.version }}_ubuntu_amd64.deb
-             asset_latest_name:      jamulus_latest_ubuntu_amd64.deb
-             asset_path_two:         deploy/Jamulus_headless_latest_amd64.deb
-             asset_name_two:         jamulus_headless_${{ needs.create_release.outputs.version }}_ubuntu_amd64.deb
-             asset_latest_name_two:  jamulus_headless_latest_ubuntu_amd64.deb
-           - os:                     macos-10.15
-             asset_path:             deploy/Jamulus-installer-mac.dmg
-             asset_name:             jamulus_${{ needs.create_release.outputs.version }}_mac.dmg
-             asset_latest_name:      jamulus_latest_mac.dmg
-           #- os:                    windows-latest
-           #  asset_path:            deploy\Jamulus-installer-win.exe
-           #  asset_latest_name:     jamulus_latest_win.exe
-           #  asset_name:            jamulus_${{ needs.create_release.outputs.upload_url }}_win.exe
+           - os:                    ubuntu-18.04
+             asset_path:            deploy/Jamulus_amd64.deb
+             asset_name:            jamulus_${{ needs.create_release.outputs.version }}_ubuntu_amd64.deb
+             asset_latest_name:     jamulus_latest_ubuntu_amd64.deb
+             asset_path_two:        deploy/Jamulus_headless_amd64.deb
+             asset_name_two:        jamulus_headless_${{ needs.create_release.outputs.version }}_ubuntu_amd64.deb
+             asset_latest_name_two: jamulus_headless_ubuntu_amd64.deb
+           - os:                    macos-10.15
+             asset_path:            deploy/Jamulus-installer-mac.dmg
+             asset_name:            jamulus_${{ needs.create_release.outputs.version }}_mac.dmg
+             asset_latest_name:     jamulus_latest_mac.dmg
+           #- os:                   windows-latest
+           #  asset_path:           ${{ github.workspace }}\deploy\Jamulus-installer-win.exe
+           #  asset_latest_name:    jamulus_latest_win.exe
+           #  asset_name:           jamulus_${{ needs.create_release.outputs.upload_url }}_win.exe
     steps:
       # checkout
-      - name:                 Checkout code
-        uses:                 actions/checkout@v2
-      - name:                 Install Qt (64 Bit)
-        uses:                 jurplel/install-qt-action@v2
-        if:                   matrix.config.os == 'windows-latest'
+      - name:                       Checkout code
+        uses:                       actions/checkout@v2
+      - name:                       Install Qt (64 Bit)
+        uses:                       jurplel/install-qt-action@v2
+        if:                         matrix.config.os == 'windows-latest'
         with:
-          version:            '5.15.2'
-          dir:                '${{ github.workspace }}'
-          arch:               'win64_msvc2019_64'
-      - name:                 Install Qt (32 Bit)
-        uses:                 jurplel/install-qt-action@v2
-        if:                   matrix.config.os == 'windows-latest'
+          version:                  '5.15.2'
+          dir:                      '${{ github.workspace }}'
+          arch:                     'win64_msvc2019_64'
+      - name:                       Install Qt (32 Bit)
+        uses:                       jurplel/install-qt-action@v2
+        if:                         matrix.config.os == 'windows-latest'
         with:
-          version:            '5.15.2'
-          dir:                '${{ github.workspace }}'
-          arch:               'win32_msvc2019'
-      - name:                 "Build deb (Linux)"
-        run:                  cd distributions; sudo ./build-debian-package-auto.sh
-        if:                   matrix.config.os == 'ubuntu-18.04'
-      - name:                 "Build (Windows)"
-        run:                  powershell .\windows\deploy_windows.ps1 ${{ github.workspace }}\Qt\5.15.2\; cp deploy\Jamulus*installer-win.exe deploy\Jamulus-installer-win.exe
-        if:                   matrix.config.os == 'windows-latest'
-      - name:                 "Build (macOS)"
-        run:                  brew install qt5; brew link qt5 --force; sh mac/deploy_mac.sh; cp deploy/Jamulus-*installer-mac.dmg deploy/Jamulus-installer-mac.dmg
-        if:                   matrix.config.os == 'macos-10.15'
-      - name:                 Upload Release Asset 1
-        id:                   upload-release-asset
-        uses:                 actions/upload-release-asset@v1
+          version:                  '5.15.2'
+          dir:                      '${{ github.workspace }}'
+          arch:                     'win32_msvc2019'
+      - name:                       "Build deb (Linux)"
+        run:                        sh linux/autorelease_linux.sh ${{ github.workspace }}
+        if:                         matrix.config.os == 'ubuntu-18.04'
+      - name:                       "Build (Windows)"
+        run:                        powershell .\windows\deploy_windows.ps1 ${{ github.workspace }}\Qt\5.15.2\; cp deploy\Jamulus*installer-win.exe deploy\Jamulus-installer-win.exe
+        if:                         matrix.config.os == 'windows-latest'
+      - name:                       "Build (macOS)"
+        run:                        sh mac/autorelease_mac.sh ${{ github.workspace }}
+        if:                         matrix.config.os == 'macos-10.15'
+      - name:                       Upload Release Asset 1
+        id:                         upload-release-asset
+        uses:                       actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url:         ${{ needs.create_release.outputs.upload_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path:         ${{ matrix.config.asset_path }}
-          asset_name:         ${{ matrix.config.asset_name }}
-          asset_content_type: application/octet-stream
-      - name:                 Upload Release Asset 2
-        if:                   matrix.config.asset_name_two != null
-        id:                   upload-release-asset-two
-        uses:                 actions/upload-release-asset@v1
+          upload_url:               ${{ needs.create_release.outputs.upload_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path:               ${{ matrix.config.asset_path }}
+          asset_name:               ${{ matrix.config.asset_name }}
+          asset_content_type:       application/octet-stream
+      - name:                       Upload Release Asset 2
+        if:                         matrix.config.asset_name_two != null
+        id:                         upload-release-asset-two
+        uses:                       actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url:         ${{ needs.create_release.outputs.upload_url }}
-          asset_path:         ${{ matrix.config.asset_path_two }}
-          asset_name:         ${{ matrix.config.asset_name_two }}
-          asset_content_type: application/octet-stream
+          upload_url:               ${{ needs.create_release.outputs.upload_url }}
+          asset_path:               ${{ matrix.config.asset_path_two }}
+          asset_name:               ${{ matrix.config.asset_name_two }}
+          asset_content_type:       application/octet-stream
 
       #### LATEST version upload ####
-      - name:                 Upload latest Release Asset 1
-        id:                   upload-latest-release-asset
-        uses:                 actions/upload-release-asset@v1
+      - name:                       Upload latest Release Asset 1
+        id:                         upload-latest-release-asset
+        uses:                       actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_latest_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path:         ${{ matrix.config.asset_path }}
-          asset_name:         ${{ matrix.config.asset_latest_name }}
-          asset_content_type: application/octet-stream
-      - name:                 Upload Release Asset 2
-        if:                   matrix.config.asset_latest_name_two != null
-        id:                   upload-latest-release-asset-two
-        uses:                 actions/upload-release-asset@v1
+          upload_url:               ${{ needs.create_release.outputs.upload_latest_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path:               ${{ matrix.config.asset_path }}
+          asset_name:               ${{ matrix.config.asset_latest_name }}
+          asset_content_type:       application/octet-stream
+      - name:                       Upload Release Asset 2
+        if:                         matrix.config.asset_latest_name_two != null
+        id:                         upload-latest-release-asset-two
+        uses:                       actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url:         ${{ needs.create_release.outputs.upload_latest_url }}
-          asset_path:         ${{ matrix.config.asset_path_two }}
-          asset_name:         ${{ matrix.config.asset_latest_name_two }}
-          asset_content_type: application/octet-stream
+          upload_url:               ${{ needs.create_release.outputs.upload_latest_url }}
+          asset_path:               ${{ matrix.config.asset_path_two }}
+          asset_name:               ${{ matrix.config.asset_latest_name_two }}
+          asset_content_type:       application/octet-stream

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -10,27 +10,40 @@ jobs:
      runs-on:                 ubuntu-latest
      outputs:
       upload_url:             ${{ steps.create_release.outputs.upload_url }}
+      upload_latest_url:      ${{ steps.create_latest_release.outputs.upload_url }}
+      version:                ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }}
      steps:
-         - name:                 Checkout code
-           uses:                 actions/checkout@v2
-         - name:              Remove latest tag
-           uses:              dev-drprasad/delete-tag-and-release@v0.1.2
-           with:
-             delete_release:  false
-             tag_name:        latest # tag name to delete
-           env:
-             GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+         - name:              Checkout code
+           uses:              actions/checkout@v2
          - name:              Get Jamulus build info
            run:               sh ${{ github.workspace }}/.github/actions_scripts/get_release_vars.sh ${{ github.workspace }}
            id:                jamulus-build-vars
-         - name:              Prepare Release
-           id:                create_release
+         - name:              Remove latest tag
+           uses:              dev-drprasad/delete-tag-and-release@v0.1.2
+           with:
+             delete_release:  true
+             tag_name:        latest # tag name to delete
+           env:
+             GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+         - name:              Prepare latest release
+           id:                create_latest_release
            uses:              actions/create-release@v1
            env:
              GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
            with:
              tag_name:        latest
              release_name:    Latest release ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }} (auto build)
+             body_path:       ${{ github.workspace }}/autoLatestChangelog.md
+             draft:           false
+             prerelease:      false
+         - name:              Prepare tag release
+           id:                create_release
+           uses:              actions/create-release@v1
+           env:
+             GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+           with:
+             tag_name:        ${{ steps.jamulus-build-vars.outputs.PUSH_TAG }}
+             release_name:    Release ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }} (auto build)
              body_path:       ${{ github.workspace }}/autoLatestChangelog.md
              draft:           false
              prerelease:      false
@@ -41,17 +54,21 @@ jobs:
     strategy:
       matrix:
         config:
-           - os:              ubuntu-18.04
-             asset_path:      deploy/Jamulus_latest_amd64.deb
-             asset_name:      jamulus_latest_ubuntu_amd64.deb
-             asset_path_two:  deploy/Jamulus_headless_latest_amd64.deb
-             asset_name_two:  jamulus_headless_latest_ubuntu_amd64.deb
-           - os:              macos-10.15
-             asset_path:      deploy/Jamulus-installer-mac.dmg
-             asset_name:      jamulus_latest_mac.dmg
-           #- os:             windows-latest
-           #  asset_path:     deploy\Jamulus-installer-win.exe
-           #  asset_name:     jamulus_latest_win.exe
+           - os:                     ubuntu-18.04
+             asset_path:             deploy/Jamulus_latest_amd64.deb
+             asset_name:             jamulus_${{ needs.create_release.outputs.version }}_ubuntu_amd64.deb
+             asset_latest_name:      jamulus_latest_ubuntu_amd64.deb
+             asset_path_two:         deploy/Jamulus_headless_latest_amd64.deb
+             asset_name_two:         jamulus_headless_${{ needs.create_release.outputs.version }}_ubuntu_amd64.deb
+             asset_latest_name_two:  jamulus_headless_latest_ubuntu_amd64.deb
+           - os:                     macos-10.15
+             asset_path:             deploy/Jamulus-installer-mac.dmg
+             asset_name:             jamulus_${{ needs.create_release.outputs.version }}_mac.dmg
+             asset_latest_name:      jamulus_latest_mac.dmg
+           #- os:                    windows-latest
+           #  asset_path:            deploy\Jamulus-installer-win.exe
+           #  asset_latest_name:     jamulus_latest_win.exe
+           #  asset_name:            jamulus_${{ needs.create_release.outputs.upload_url }}_win.exe
     steps:
       # checkout
       - name:                 Checkout code
@@ -85,7 +102,7 @@ jobs:
         env:
           GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url:         ${{ needs.create_release.outputs.upload_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path:         ${{ matrix.config.asset_path }}
           asset_name:         ${{ matrix.config.asset_name }}
           asset_content_type: application/octet-stream
@@ -99,4 +116,27 @@ jobs:
           upload_url:         ${{ needs.create_release.outputs.upload_url }}
           asset_path:         ${{ matrix.config.asset_path_two }}
           asset_name:         ${{ matrix.config.asset_name_two }}
+          asset_content_type: application/octet-stream
+
+      #### LATEST version upload ####
+      - name:                 Upload latest Release Asset 1
+        id:                   upload-latest-release-asset
+        uses:                 actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_latest_url }} # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path:         ${{ matrix.config.asset_path }}
+          asset_name:         ${{ matrix.config.asset_latest_name }}
+          asset_content_type: application/octet-stream
+      - name:                 Upload Release Asset 2
+        if:                   matrix.config.asset_latest_name_two != null
+        id:                   upload-latest-release-asset-two
+        uses:                 actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url:         ${{ needs.create_release.outputs.upload_latest_url }}
+          asset_path:         ${{ matrix.config.asset_path_two }}
+          asset_name:         ${{ matrix.config.asset_latest_name_two }}
           asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ debug/
 release/
 build/
 deploy/
+debian/
+build-gui/
+build-nox/
 jamulus.sln
 jamulus.vcxproj
 jamulus.vcxproj.filters

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -3,15 +3,6 @@
 # set armhf
 #sudo dpkg --add-architecture armhf
 
-echo "Update system..."
-sudo apt-get -qq update
-# We don't upgrade the packages. If this is needed, just uncomment this line
-# sudo apt-get -qq -y upgrade
-echo "Install dependencies..."
-
-sudo apt-get -qq -y install devscripts build-essential \
- debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools # gcc-arm-linux-gnueabihf
-
 cp -r debian ..
 cd ..
 
@@ -39,12 +30,3 @@ echo "${VERSION} building..."
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 
 debuild -b -us -uc
-
-mkdir deploy
-
-#debuild -b -us -uc -aarmhf
-# copy for auto release
-cp ../*.deb deploy/
-
-mv deploy/jamulus-headless*_amd64.deb deploy/Jamulus_headless_latest_amd64.deb
-mv deploy/jamulus*_amd64.deb deploy/Jamulus_latest_amd64.deb

--- a/linux/autorelease_linux.sh
+++ b/linux/autorelease_linux.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+
+# please run this script with the first parameter being the root of the repo
+if [ -z "${1}" ]; then
+    echo "Please give the path to the repository root as second parameter to this script!"
+    exit 1
+fi
+
+echo "Update system..."
+sudo apt-get -qq update
+# We don't upgrade the packages. If this is needed, just uncomment this line
+# sudo apt-get -qq -y upgrade
+echo "Install dependencies..."
+
+sudo apt-get -qq -y install devscripts build-essential \
+ debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools
+
+
+cd ${1}/distributions
+
+sudo ./build-debian-package-auto.sh
+
+mkdir ${1}/deploy
+
+#debuild -b -us -uc -aarmhf
+# copy for auto release
+cp ${1}/../*.deb ${1}/deploy/
+
+# rename them
+
+mv ${1}/deploy/jamulus-headless*_amd64.deb ${1}/deploy/Jamulus_headless_amd64.deb
+mv ${1}/deploy/jamulus*_amd64.deb ${1}/deploy/Jamulus_amd64.deb

--- a/mac/autorelease_mac.sh
+++ b/mac/autorelease_mac.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+
+# please run this script with the first parameter being the root of the repo
+if [ -z "${1}" ]; then
+    echo "Please give the path to the repository root as second parameter to this script!"
+    exit 1
+fi
+
+cd ${1}
+
+echo "Install dependencies..."
+brew install qt5
+brew link qt5 --force
+echo "Run deploy script..."
+sh ${1}/mac/deploy_mac.sh
+cp ${1}/deploy/Jamulus-*installer-mac.dmg ${1}/deploy/Jamulus-installer-mac.dmg

--- a/windows/autorelease_windows.bat
+++ b/windows/autorelease_windows.bat
@@ -1,0 +1,1 @@
+# Todo once the new installer is ready


### PR DESCRIPTION
As discussed in my last PR. 

https://github.com/corrados/jamulus/pull/833#issuecomment-759727238

In a next step we should make this less messy:

My proposal:

Create one script for each OS in e.g. /linux named autorelease_linux.sh which builds installs dependencies, builds Jamulus and moves the content to /deploy

Getting the dependencies (Qt) seems to be difficult. Therefore we can't download them for Windows.

@pljones 

Another question: Why is the /distributions folder not in /linux?