### PR TITLE
Support chat history storage in file (#276)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 ### 3.6.2git <- NOTE: the release version number will be 3.6.3 ###
 
+- support a chatlog on the client (#276)
+
 - show --clientname as first word in title to avoid clipping in Windows task bar (#789)
 
 

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -26,8 +26,10 @@
 
 
 /* Implementation *************************************************************/
-CChatDlg::CChatDlg ( QWidget* parent ) :
-    CBaseDlg ( parent, Qt::Window ) // use Qt::Window to get min/max window buttons
+CChatDlg::CChatDlg ( CClientSettings* pNSetP,
+                     QWidget*         parent ) :
+    CBaseDlg  ( parent, Qt::Window ), // use Qt::Window to get min/max window buttons
+    pSettings ( pNSetP )
 {
     setupUi ( this );
 
@@ -57,6 +59,14 @@ CChatDlg::CChatDlg ( QWidget* parent ) :
 
     // set a placeholder text to make sure where to type the message in (#384)
     edtLocalInputText->setPlaceholderText ( tr ( "Type a message here" ) );
+
+    // load the chat history
+    pSettings->LoadChat ( slMessageStorage );
+
+    for ( int i = 0; i < slMessageStorage.size(); i++ )
+    {
+        txvChatWindow->append ( slMessageStorage[i] );
+    }
 
 
     // Menu  -------------------------------------------------------------------
@@ -107,6 +117,7 @@ void CChatDlg::OnClearChatHistory()
 {
     // clear chat window
     txvChatWindow->clear();
+    slMessageStorage.clear();
 }
 
 void CChatDlg::AddChatText ( QString strChatText )
@@ -124,8 +135,9 @@ void CChatDlg::AddChatText ( QString strChatText )
         strChatText.replace ( QRegExp ( "(https://\\S+)" ), "<a href=\"\\1\">\\1</a>" );
     }
 
-    // add new text in chat window
+    // add new text in chat window and storage
     txvChatWindow->append ( strChatText );
+    slMessageStorage << strChatText;
 }
 
 void CChatDlg::OnAnchorClicked ( const QUrl& Url )

--- a/src/chatdlg.h
+++ b/src/chatdlg.h
@@ -36,6 +36,7 @@
 #include <QMessageBox>
 #include "global.h"
 #include "util.h"
+#include "settings.h"
 #include "ui_chatdlgbase.h"
 
 
@@ -45,9 +46,15 @@ class CChatDlg : public CBaseDlg, private Ui_CChatDlgBase
     Q_OBJECT
 
 public:
-    CChatDlg ( QWidget* parent = nullptr );
+    CChatDlg ( CClientSettings* pNSetP,
+               QWidget*         parent = nullptr );
 
     void AddChatText ( QString strChatText );
+    void SaveChatHistory() { pSettings->SaveChat ( slMessageStorage ); }
+
+protected:
+    CClientSettings* pSettings;
+    QStringList      slMessageStorage;
 
 public slots:
     void OnSendText();

--- a/src/chatdlg.h
+++ b/src/chatdlg.h
@@ -50,7 +50,7 @@ public:
                QWidget*         parent = nullptr );
 
     void AddChatText ( QString strChatText );
-    void SaveChatHistory() { pSettings->SaveChat ( slMessageStorage ); }
+    void SaveChatHistory() { pSettings->SaveChat ( slMessageStorage.mid ( std::max ( 0, slMessageStorage.size() - MAX_CHAT_LINES_IN_HISTORY ) ) ); }
 
 protected:
     CClientSettings* pSettings;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -40,7 +40,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     bConnectDlgWasShown ( false ),
     bMIDICtrlUsed       ( !strMIDISetup.isEmpty() ),
     ClientSettingsDlg   ( pNCliP, pNSetP, parent ),
-    ChatDlg             ( parent ),
+    ChatDlg             ( pNSetP, parent ),
     ConnectDlg          ( pNSetP, bNewShowComplRegConnList, parent ),
     AnalyzerConsole     ( pNCliP, parent ),
     MusicianProfileDlg  ( pNCliP, parent )
@@ -599,6 +599,8 @@ void CClientDlg::closeEvent ( QCloseEvent* Event )
     pSettings->bConnectDlgShowAllMusicians = ConnectDlg.GetShowAllMusicians();
     pSettings->eChannelSortType            = MainMixerBoard->GetFaderSorting();
     pSettings->iNumMixerPanelRows          = MainMixerBoard->GetNumMixerPanelRows();
+
+    ChatDlg.SaveChatHistory();
 
     // default implementation of this event handler routine
     Event->accept();

--- a/src/global.h
+++ b/src/global.h
@@ -83,7 +83,7 @@ LED bar:      lbr
 // default names of the ini-file for client and server
 #define DEFAULT_INI_FILE_NAME            "Jamulus.ini"
 #define DEFAULT_INI_FILE_NAME_SERVER     "Jamulusserver.ini"
-#define DEFAULT_CHAT_FILE_NAME           "ChatHistory.txt"
+#define DEFAULT_CHAT_FILE_NAME           "Chathistory.txt"
 
 // file name for logging file
 #define DEFAULT_LOG_FILE_NAME            "Jamulussrvlog.txt"

--- a/src/global.h
+++ b/src/global.h
@@ -83,6 +83,7 @@ LED bar:      lbr
 // default names of the ini-file for client and server
 #define DEFAULT_INI_FILE_NAME            "Jamulus.ini"
 #define DEFAULT_INI_FILE_NAME_SERVER     "Jamulusserver.ini"
+#define DEFAULT_CHAT_FILE_NAME           "ChatHistory.txt"
 
 // file name for logging file
 #define DEFAULT_LOG_FILE_NAME            "Jamulussrvlog.txt"

--- a/src/global.h
+++ b/src/global.h
@@ -217,6 +217,8 @@ LED bar:      lbr
 // to SERVLIST_REGIST_INTERV_MINUTES)
 #define REGISTER_SERVER_RETRY_LIMIT      5 // count
 
+// maximum number of chat lines stored in the chat history file
+#define MAX_CHAT_LINES_IN_HISTORY        1000
 
 // Maximum length of fader tag and text message strings (Since for chat messages
 // some HTML code is added, we also have to define a second length which includes

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -50,6 +50,37 @@ void CSettings::Save()
     WriteToFile ( strFileName, IniXMLDocument );
 }
 
+void CSettings::LoadChat ( QStringList& slChat )
+{
+    QFile file ( strFileNameChat );
+
+    if ( file.open ( QIODevice::ReadOnly ) )
+    {
+        QTextStream Stream ( &file );
+        QString     strCurLine;
+
+        while ( Stream.readLineInto ( &strCurLine ) )
+        {
+            slChat << strCurLine;
+        }
+        file.close();
+    }
+}
+
+void CSettings::SaveChat ( const QStringList& slChat )
+{
+    QFile file ( strFileNameChat );
+
+    if ( file.open ( QIODevice::WriteOnly | QIODevice::Truncate ) )
+    {
+        for ( int i = 0; i < slChat.size(); i++ )
+        {
+            QTextStream ( &file ) << slChat[i] << endl;
+        }
+        file.close();
+    }
+}
+
 void CSettings::ReadFromFile ( const QString& strCurFileName,
                                QDomDocument&  XMLDocument )
 {
@@ -96,7 +127,8 @@ void CSettings::SetFileName ( const QString& sNFiName,
         }
 
         // append the actual file name
-        strFileName = sConfigDir + "/" + sDefaultFileName;
+        strFileName     = sConfigDir + "/" + sDefaultFileName;
+        strFileNameChat = sConfigDir + "/" + DEFAULT_CHAT_FILE_NAME;
     }
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -47,7 +47,8 @@ public:
     CSettings() :
         vecWindowPosMain ( ), // empty array
         strLanguage      ( "" ),
-        strFileName      ( "" )
+        strFileName      ( "" ),
+        strFileNameChat  ( "" )
     {
         QObject::connect ( QCoreApplication::instance(), &QCoreApplication::aboutToQuit,
             this, &CSettings::OnAboutToQuit );
@@ -55,6 +56,9 @@ public:
 
     void Load ( const QList<QString> CommandLineOptions );
     void Save();
+
+    void LoadChat ( QStringList& slChat );
+    void SaveChat ( const QStringList& slChat );
 
     // common settings
     QByteArray vecWindowPosMain;
@@ -127,6 +131,7 @@ protected:
                          const QString& sValue = "" );
 
     QString strFileName;
+    QString strFileNameChat;
 
 public slots:
     void OnAboutToQuit() { Save(); }


### PR DESCRIPTION
This code is about to implement  #276. This functionality is enabled by default, i.e., you do not get an empty chat dialog on startup of the Jamulus software. The only way you can get rid of old messages is to explicitely clear the text with the given menu entry. Actually, that is the intention of a chat history.

I think, I just have to get used to that new functionality. If you are able to compile and test this code, feedback is welcome.

I was thinking of adding a limit of number of lines which can be stored in the history to make sure we do not get memory issues. If someone never clears the chat history, that would be a problem at some point. So this is still missing.