### PR TITLE
qmake: avoid unnecessary runtime dependencies

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -309,6 +309,12 @@ win32 {
     # we want to compile with C++11
     CONFIG += c++11
 
+    # --as-needed avoids linking the final binary against unnecessary runtime
+    # libs. Most g++ versions already do that by default.
+    # However, Debian buster does not and would link against libQt5Concurrent
+    # unnecessarily without this workaround (#741):
+    QMAKE_LFLAGS += -Wl,--as-needed
+
     HEADERS += linux/sound.h
     SOURCES += linux/sound.cpp
 


### PR DESCRIPTION
Most g++ versions already seem to use --as-needed in the ld invocations by default. Some versions such as Debian buster's don't. This leads to an unnecessary runtime dependency on libQt5Concurrent.so.

This PR ensures that qmake passes --as-needed in all cases to avoid this.

Fixes #741.
Verified build on: Arch Linux, g++ 10.2.0
Verified build on: Debian buster, g++ 8.3.0

@ann0see Can you verify that this works in your setup/build as well?