### PR TITLE
Enable automatic building on Windows

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -76,10 +76,10 @@ jobs:
              asset_path:            deploy/Jamulus-installer-mac.dmg
              asset_name:            jamulus_${{ needs.create_release.outputs.version }}_mac.dmg
              asset_latest_name:     jamulus_latest_mac.dmg
-           #- os:                   windows-latest
-           #  asset_path:           ${{ github.workspace }}\deploy\Jamulus-installer-win.exe
-           #  asset_latest_name:    jamulus_latest_win.exe
-           #  asset_name:           jamulus_${{ needs.create_release.outputs.upload_url }}_win.exe
+           - os:                    windows-latest
+             asset_path:            deploy\Jamulus-installer-win.exe
+             asset_latest_name:     jamulus_latest_win.exe
+             asset_name:            jamulus_${{ needs.create_release.outputs.upload_url }}_win.exe
 
     steps:
 
@@ -88,21 +88,6 @@ jobs:
       # Get the code
       - name:                       Checkout code
         uses:                       actions/checkout@v2
-      # Install Qt (currently Windows only)
-      - name:                       Install Qt (64 Bit)
-        uses:                       jurplel/install-qt-action@v2
-        if:                         matrix.config.os == 'windows-latest'
-        with:
-          version:                  '5.15.2'
-          dir:                      '${{ github.workspace }}'
-          arch:                     'win64_msvc2019_64'
-      - name:                       Install Qt (32 Bit)
-        uses:                       jurplel/install-qt-action@v2
-        if:                         matrix.config.os == 'windows-latest'
-        with:
-          version:                  '5.15.2'
-          dir:                      '${{ github.workspace }}'
-          arch:                     'win32_msvc2019'
 
       ### Build ###
 
@@ -110,7 +95,7 @@ jobs:
         run:                        sh linux/autorelease_linux.sh ${{ github.workspace }}
         if:                         matrix.config.os == 'ubuntu-18.04'
       - name:                       "Build (Windows)"
-        run:                        powershell .\windows\deploy_windows.ps1 ${{ github.workspace }}\Qt\5.15.2\; cp deploy\Jamulus*installer-win.exe deploy\Jamulus-installer-win.exe
+        run:                        powershell .\windows\autorelease_windows.ps1 -sourcepath "${{ github.workspace }}"
         if:                         matrix.config.os == 'windows-latest'
       - name:                       "Build (macOS)"
         run:                        sh mac/autorelease_mac.sh ${{ github.workspace }}
@@ -154,7 +139,7 @@ jobs:
           asset_path:               ${{ matrix.config.asset_path }}
           asset_name:               ${{ matrix.config.asset_latest_name }}
           asset_content_type:       application/octet-stream
-      - name:                       Upload Release Asset 2
+      - name:                       Upload latest Release Asset 2
         if:                         matrix.config.asset_latest_name_two != null
         id:                         upload-latest-release-asset-two
         uses:                       actions/upload-release-asset@v1

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ debug/
 release/
 build/
 deploy/
-debian/
 build-gui/
 build-nox/
 jamulus.sln

--- a/windows/autorelease_windows.bat
+++ b/windows/autorelease_windows.bat
@@ -1,1 +1,0 @@
-# Sets up the environment for autobuild on Windows

--- a/windows/autorelease_windows.ps1
+++ b/windows/autorelease_windows.ps1
@@ -1,0 +1,19 @@
+# Sets up the environment for autobuild on Windows
+
+# Get the source path via parameter
+param ([string] $sourcepath)
+
+echo "Install Qt..."
+# Install Qt
+pip install aqtinstall
+echo "Get Qt 64 bit..."
+aqt install --outputdir C:\Qt 5.15.2 windows desktop win64_msvc2019_64
+echo "Get Qt 32 bit..."
+aqt install --outputdir C:\Qt 5.15.2 windows desktop win32_msvc2019
+
+echo "Build installer..."
+# Build the installer
+powershell "$sourcepath\windows\deploy_windows.ps1" "C:\Qt\5.15.2"
+
+# Rename the installer
+cp "$sourcepath\deploy\Jamulus*installer-win.exe" "$sourcepath\deploy\Jamulus-installer-win.exe"


### PR DESCRIPTION
I'm not yet 100% sure if I added enough but this should enable building on Windows via GH Actions.
Qt will be installed via aqt directly now, not by using the GitHub action. This results in a binary that works without errors.
I've also removed the debian directory from the .gitignore file since it also ignores the directory in /distributions which is not wanted.

This PR depends on #841 