### PR TITLE
#475 git hash & status in verison info

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 
 
-### 3.6.2git <- NOTE: the release version number will be 3.6.3 ###
+### 3.6.2dev <- NOTE: the release version number will be 3.6.3 ###
 
 - show --clientname as first word in title to avoid clipping in Windows task bar (#789)
 

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1,4 +1,4 @@
-VERSION = 3.6.2
+VERSION = 3.6.2dev
 
 # use target name which does not use a captital letter at the beginning
 contains(CONFIG, "noupcasename") {
@@ -8,7 +8,12 @@ contains(CONFIG, "noupcasename") {
 
 #allow detailed version info for intermediate builds
 contains(CONFIG, "official_release_version") {
+	#for creating a new release:
+	# - count the VERSION up 
+	# - create a new commit
+	# - run build with "official_release_version" on it
     message(building an official release version)
+	VERSION = ($$replace(VERSION, dev, ))
 } else {
     GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty) # the match should never match
     VERSION = "$$VERSION"-$$GIT_DESCRIPTION

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -7,17 +7,12 @@ contains(CONFIG, "noupcasename") {
 }
 
 #allow detailed version info for intermediate builds
-contains(CONFIG, "official_release_version") {
-	#for creating a new release:
-	# - count the VERSION up 
-	# - create a new commit
-	# - run build with "official_release_version" on it
-    message(building an official release version)
-	VERSION = ($$replace(VERSION, dev, ))
-} else {
+if (contains(VERSION, .*dev.*)) {
     GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty) # the match should never match
     VERSION = "$$VERSION"-$$GIT_DESCRIPTION
     message(building an intermediate version: $$VERSION)
+} else {
+    message(building a final release version: $$VERSION)
 }
 
 

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1,10 +1,21 @@
-VERSION = 3.6.2git
+VERSION = 3.6.2
 
 # use target name which does not use a captital letter at the beginning
 contains(CONFIG, "noupcasename") {
     message(The target name is jamulus instead of Jamulus.)
     TARGET = jamulus
 }
+
+#allow detailed version info for intermediate builds
+contains(CONFIG, "official_release_version") {
+    message(building an official release version)
+} else {
+    GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty) # the match should never match
+    VERSION = "$$VERSION"-$$GIT_DESCRIPTION
+    TARGET = "$$TARGET"-$$VERSION
+    message(building an intermediate version: $$TARGET)
+}
+
 
 CONFIG += qt \
     thread \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -12,8 +12,7 @@ contains(CONFIG, "official_release_version") {
 } else {
     GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty) # the match should never match
     VERSION = "$$VERSION"-$$GIT_DESCRIPTION
-    TARGET = "$$TARGET"-$$VERSION
-    message(building an intermediate version: $$TARGET)
+    message(building an intermediate version: $$VERSION)
 }
 
 


### PR DESCRIPTION
my answer to #475 

for all "normal" builds a git hash will be appended, separated to the version with a "-"
by specifying "official_release_version" in CONFIG this is not happening

"3.6.2"  << official release
"3.6.2-37f993aa" << intermediate release
"3.6.2-37f993aa-dirty" << intermediate release

tested on windows looking at the "about" info