### PR TITLE
 Delete release on action start

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -38,7 +38,7 @@ jobs:
            continue-on-error:       true
            uses:                    dev-drprasad/delete-tag-and-release@v0.1.2
            with:
-             delete_release:        false
+             delete_release:        true
              tag_name:              ${{ steps.jamulus-build-vars.outputs.RELEASE_TAG }}
            env:
              GITHUB_TOKEN:          ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If we don't remove the old release (especially the one tagged with latest) only a draft release will be created.

See: https://github.com/ann0see/jamulus/commit/66e0b6eeb1298b33aef8abec53c5349231abb5f7